### PR TITLE
feat: 发布资源 Mapping 快照

### DIFF
--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/annotations/ResourcePermission.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/annotations/ResourcePermission.java
@@ -1,0 +1,23 @@
+package io.github.opensabre.boot.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares stable authorization metadata for a Spring MVC endpoint.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ResourcePermission {
+    String code() default "";
+
+    String name() default "";
+
+    String type() default "";
+
+    String description() default "";
+
+    boolean register() default true;
+}

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/entity/ResourceMappingSnapshot.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/entity/ResourceMappingSnapshot.java
@@ -1,0 +1,21 @@
+package io.github.opensabre.boot.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+/**
+ * Complete MVC resource snapshot emitted by one application instance.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResourceMappingSnapshot {
+    private String application;
+    private String version;
+    private Set<RestMappingInfo> resources;
+}

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/entity/RestMappingInfo.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/entity/RestMappingInfo.java
@@ -1,23 +1,32 @@
 package io.github.opensabre.boot.entity;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 /**
  * Rest注册信息
  */
 @Data
-@RequiredArgsConstructor
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RestMappingInfo {
     /**
      * Rest 的path url，如：/user/{name}
      */
-    @NonNull
     private String url;
     /**
      * Rest 的方法，如：GET/POST ..
      */
-    @NonNull
     private String method;
+
+    private String code;
+    private String name;
+    private String type;
+    private String description;
+    private String handlerClass;
+    private String handlerMethod;
+    private boolean declaredPermission;
 }

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/entity/RestMappingInfo.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/entity/RestMappingInfo.java
@@ -14,6 +14,17 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class RestMappingInfo {
     /**
+     * Preserves the original public constructor used by legacy mapping listeners.
+     *
+     * @param url mapping path
+     * @param method HTTP method
+     */
+    public RestMappingInfo(String url, String method) {
+        this.url = url;
+        this.method = method;
+    }
+
+    /**
      * Rest 的path url，如：/user/{name}
      */
     private String url;

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/event/OpensabreStartedEventHandler.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/event/OpensabreStartedEventHandler.java
@@ -1,12 +1,16 @@
 package io.github.opensabre.boot.event;
 
+import io.github.opensabre.boot.entity.ResourceMappingSnapshot;
+import io.github.opensabre.boot.entity.RestMappingInfo;
 import io.github.opensabre.boot.rest.MappingInfoHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationListener;
+import org.springframework.core.env.Environment;
 
 import jakarta.annotation.Resource;
+import java.util.Set;
 
 /**
  * springboot应用启动完成后，发送Rest注册事件
@@ -24,12 +28,24 @@ public class OpensabreStartedEventHandler implements ApplicationListener<Applica
     @Resource
     MappingInfoHandler mappingInfoHandler;
 
+    @Resource
+    Environment environment;
+
     @Override
     public void onApplicationEvent(ApplicationReadyEvent event) {
         log.info("ApplicationReadyEvent received");
-        mappingInfoHandler.getMappingInfo().forEach(mappingInfo -> {
+        Set<RestMappingInfo> mappings = mappingInfoHandler.getMappingInfo();
+        mappings.forEach(mappingInfo -> {
             context.publishEvent(new MappingRegisteredEvent(mappingInfo));
             log.info("Mapping Registered :{}", mappingInfo);
         });
+        ResourceMappingSnapshot snapshot = ResourceMappingSnapshot.builder()
+                .application(environment.getProperty("spring.application.name", context.getApplicationName()))
+                .version(environment.getProperty("info.app.version", "unknown"))
+                .resources(mappings)
+                .build();
+        context.publishEvent(new ResourceMappingsRegisteredEvent(snapshot));
+        log.info("Resource mapping snapshot registered: application={}, count={}",
+                snapshot.getApplication(), mappings.size());
     }
 }

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/event/ResourceMappingsRegisteredEvent.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/event/ResourceMappingsRegisteredEvent.java
@@ -1,0 +1,17 @@
+package io.github.opensabre.boot.event;
+
+import io.github.opensabre.boot.entity.ResourceMappingSnapshot;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Published once after the complete MVC resource snapshot has been collected.
+ */
+public class ResourceMappingsRegisteredEvent extends ApplicationEvent {
+    public ResourceMappingsRegisteredEvent(ResourceMappingSnapshot source) {
+        super(source);
+    }
+
+    public ResourceMappingSnapshot getSnapshot() {
+        return (ResourceMappingSnapshot) getSource();
+    }
+}

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/rest/MappingInfoHandler.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/rest/MappingInfoHandler.java
@@ -1,13 +1,16 @@
 package io.github.opensabre.boot.rest;
 
+import io.github.opensabre.boot.annotations.ResourcePermission;
 import io.github.opensabre.boot.entity.RestMappingInfo;
+import io.swagger.v3.oas.annotations.Operation;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import jakarta.annotation.Resource;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,15 +35,64 @@ public class MappingInfoHandler {
     public Set<RestMappingInfo> getMappingInfo() {
         // 拿到Handler适配器中的全部方法
         Map<RequestMappingInfo, HandlerMethod> methodMap = requestMappingHandlerMapping.getHandlerMethods();
-        Set<RestMappingInfo> interfaceInfos = new HashSet<>();
-        for (RequestMappingInfo requestMappingInfo : methodMap.keySet()) {
-            Set<String> urls = requestMappingInfo.getPathPatternsCondition().getPatternValues();
+        Set<RestMappingInfo> interfaceInfos = new LinkedHashSet<>();
+        for (Map.Entry<RequestMappingInfo, HandlerMethod> entry : methodMap.entrySet()) {
+            RequestMappingInfo requestMappingInfo = entry.getKey();
+            HandlerMethod handlerMethod = entry.getValue();
+            if (isFrameworkHandler(handlerMethod)) {
+                continue;
+            }
+            ResourcePermission permission = handlerMethod.getMethodAnnotation(ResourcePermission.class);
+            if (permission != null && !permission.register()) {
+                continue;
+            }
+            Set<String> urls = getPatternValues(requestMappingInfo);
             Set<RequestMethod> methods = requestMappingInfo.getMethodsCondition().getMethods();
+            if (methods.isEmpty()) {
+                continue;
+            }
+            Operation operation = handlerMethod.getMethodAnnotation(Operation.class);
             Set<RestMappingInfo> interfaceInfoSet = urls.stream()
-                    .flatMap(url -> methods.stream().map(method -> new RestMappingInfo(url, method.name())))
+                    .flatMap(url -> methods.stream().map(method -> toMappingInfo(
+                            url, method, handlerMethod, permission, operation)))
                     .collect(Collectors.toSet());
             interfaceInfos.addAll(interfaceInfoSet);
         }
         return interfaceInfos;
+    }
+
+    private Set<String> getPatternValues(RequestMappingInfo mappingInfo) {
+        if (mappingInfo.getPathPatternsCondition() != null) {
+            return mappingInfo.getPathPatternsCondition().getPatternValues();
+        }
+        if (mappingInfo.getPatternsCondition() != null) {
+            return mappingInfo.getPatternsCondition().getPatterns();
+        }
+        return Set.of();
+    }
+
+    private boolean isFrameworkHandler(HandlerMethod handlerMethod) {
+        String className = handlerMethod.getBeanType().getName();
+        return className.startsWith("org.springframework.") || className.startsWith("org.springdoc.");
+    }
+
+    private RestMappingInfo toMappingInfo(String url, RequestMethod method, HandlerMethod handlerMethod,
+                                          ResourcePermission permission, Operation operation) {
+        String operationName = operation == null ? null : operation.summary();
+        String operationDescription = operation == null ? null : operation.description();
+        return RestMappingInfo.builder()
+                .url(url)
+                .method(method.name())
+                .code(permission == null ? null : permission.code())
+                .name(permission == null
+                        ? StringUtils.defaultIfBlank(operationName, handlerMethod.getMethod().getName())
+                        : permission.name())
+                .type(permission == null ? null : permission.type())
+                .description(permission == null ? operationDescription
+                        : StringUtils.defaultIfBlank(permission.description(), operationDescription))
+                .handlerClass(handlerMethod.getBeanType().getName())
+                .handlerMethod(handlerMethod.getMethod().getName())
+                .declaredPermission(permission != null)
+                .build();
     }
 }

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/rest/MappingInfoHandler.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/boot/rest/MappingInfoHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
 import jakarta.annotation.Resource;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -47,10 +48,9 @@ public class MappingInfoHandler {
                 continue;
             }
             Set<String> urls = getPatternValues(requestMappingInfo);
-            Set<RequestMethod> methods = requestMappingInfo.getMethodsCondition().getMethods();
-            if (methods.isEmpty()) {
-                continue;
-            }
+            Set<RequestMethod> declaredMethods = requestMappingInfo.getMethodsCondition().getMethods();
+            Set<RequestMethod> methods = declaredMethods.isEmpty()
+                    ? EnumSet.allOf(RequestMethod.class) : declaredMethods;
             Operation operation = handlerMethod.getMethodAnnotation(Operation.class);
             Set<RestMappingInfo> interfaceInfoSet = urls.stream()
                     .flatMap(url -> methods.stream().map(method -> toMappingInfo(

--- a/opensabre-starter-webmvc/src/test/java/io/github/opensabre/boot/entity/RestMappingInfoCompatibilityTest.java
+++ b/opensabre-starter-webmvc/src/test/java/io/github/opensabre/boot/entity/RestMappingInfoCompatibilityTest.java
@@ -1,0 +1,17 @@
+package io.github.opensabre.boot.entity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Verifies compatibility of the mapping metadata API used by legacy listeners. */
+class RestMappingInfoCompatibilityTest {
+
+    @Test
+    void legacyConstructorShouldRemainAvailable() {
+        RestMappingInfo mapping = new RestMappingInfo("/users", "GET");
+
+        assertThat(mapping.getUrl()).isEqualTo("/users");
+        assertThat(mapping.getMethod()).isEqualTo("GET");
+    }
+}

--- a/opensabre-starter-webmvc/src/test/java/io/github/opensabre/boot/rest/MappingInfoHandlerTest.java
+++ b/opensabre-starter-webmvc/src/test/java/io/github/opensabre/boot/rest/MappingInfoHandlerTest.java
@@ -1,0 +1,62 @@
+package io.github.opensabre.boot.rest;
+
+import io.github.opensabre.boot.annotations.ResourcePermission;
+import io.github.opensabre.boot.entity.RestMappingInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+/** Covers resource snapshot collection semantics. */
+class MappingInfoHandlerTest {
+
+    @Test
+    void methodlessMappingShouldExpandToEveryHttpMethod() throws Exception {
+        MappingInfoHandler handler = handlerFor("included", RequestMappingInfo.paths("/any").build());
+
+        Set<RestMappingInfo> mappings = handler.getMappingInfo();
+
+        assertThat(mappings).hasSize(RequestMethod.values().length);
+        assertThat(mappings).extracting(RestMappingInfo::getMethod)
+                .containsExactlyInAnyOrder(java.util.Arrays.stream(RequestMethod.values())
+                        .map(Enum::name).toArray(String[]::new));
+    }
+
+    @Test
+    void registerFalseShouldExcludeInternalMapping() throws Exception {
+        MappingInfoHandler handler = handlerFor("excluded",
+                RequestMappingInfo.paths("/internal").methods(RequestMethod.PUT).build());
+
+        assertThat(handler.getMappingInfo()).isEmpty();
+    }
+
+    private MappingInfoHandler handlerFor(String methodName, RequestMappingInfo mappingInfo) throws Exception {
+        Method method = TestController.class.getDeclaredMethod(methodName);
+        Map<RequestMappingInfo, HandlerMethod> methods = Map.of(
+                mappingInfo, new HandlerMethod(new TestController(), method));
+        RequestMappingHandlerMapping mapping = new RequestMappingHandlerMapping() {
+            @Override
+            public Map<RequestMappingInfo, HandlerMethod> getHandlerMethods() {
+                return methods;
+            }
+        };
+        MappingInfoHandler handler = new MappingInfoHandler();
+        handler.requestMappingHandlerMapping = mapping;
+        return handler;
+    }
+
+    private static class TestController {
+        void included() {
+        }
+
+        @ResourcePermission(register = false)
+        void excluded() {
+        }
+    }
+}


### PR DESCRIPTION
## 功能说明

- 新增 `@ResourcePermission` 注解，支持声明稳定的资源编码和元数据
- 增强 Mapping 收集结果，包含处理类、处理方法及 OpenAPI 描述
- 应用启动后发布完整的资源 Mapping 快照事件
- 保留原有单条 `MappingRegisteredEvent`，保证向后兼容
- 支持通过 `register = false` 排除内部接口

## 验证

- `mvn -DskipTests install` 通过
- `git diff --check` 通过

## 后续

`base-organization` 的自动资源入库 PR 依赖本 PR。