### PR TITLE
feat: 显式上报错误码定义归属

### DIFF
--- a/docs/modules/error-catalog.md
+++ b/docs/modules/error-catalog.md
@@ -13,4 +13,8 @@ ErrorCatalogProvider orderErrorCatalogProvider() {
 
 所有参与上报的应用与 `base-sysadmin` 必须配置相同的 `ERROR_CATALOG_REGISTRATION_TOKEN`。目录端拒绝空凭据、无效凭据和被其他应用占用的错误码。
 
+Framework 在发送快照前会补齐定义归属：业务 Provider 的错误码归当前应用所有，
+范围为 `APPLICATION`；内置 `SystemErrorType` 归 `opensabre-framework` 所有，
+范围为 `COMMON`。公共定义可由多个应用幂等上报，但内容必须完全一致。
+
 管理端通过“系统管理 / 错误码目录”按错误码、文案、模块、应用与废弃状态查询；目录为声明快照，不会改变应用运行时的异常返回。

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/OpensabreGovernanceConfig.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/OpensabreGovernanceConfig.java
@@ -87,7 +87,9 @@ public class OpensabreGovernanceConfig {
 
     @Bean
     @ConditionalOnMissingBean(name = "systemErrorCatalogProvider")
-    public ErrorCatalogProvider systemErrorCatalogProvider() { return ErrorCatalogProvider.of("framework", SystemErrorType.values()); }
+    public ErrorCatalogProvider systemErrorCatalogProvider() {
+        return ErrorCatalogProvider.common("opensabre-framework", "framework", SystemErrorType.values());
+    }
 
     @Bean
     @ConditionalOnProperty(prefix = "opensabre.governance.error-catalog", name = "enabled", havingValue = "true", matchIfMissing = true)

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogEntry.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogEntry.java
@@ -4,13 +4,35 @@ import io.github.opensabre.common.core.exception.ErrorType;
 
 /** A stable, centrally searchable description of one application error code. */
 public record ErrorCatalogEntry(String code, String message, String module, Integer httpStatus,
-                                boolean publicVisible, boolean deprecated, String description) {
+                                boolean publicVisible, boolean deprecated, String description,
+                                String owner, ErrorCatalogScope scope) {
     public ErrorCatalogEntry {
         if (isBlank(code) || isBlank(message)) throw new IllegalArgumentException("code and message are required");
         module = isBlank(module) ? "default" : module;
     }
-    public static ErrorCatalogEntry from(ErrorType errorType, String module) {
-        return new ErrorCatalogEntry(errorType.getCode(), errorType.getMesg(), module, null, true, false, null);
+
+    /**
+     * Backward-compatible constructor for application-defined error codes.
+     */
+    public ErrorCatalogEntry(String code, String message, String module, Integer httpStatus,
+                             boolean publicVisible, boolean deprecated, String description) {
+        this(code, message, module, httpStatus, publicVisible, deprecated, description, null, null);
     }
+
+    public static ErrorCatalogEntry from(ErrorType errorType, String module) {
+        return new ErrorCatalogEntry(errorType.getCode(), errorType.getMesg(), module,
+                null, true, false, null, null, null);
+    }
+
+    /**
+     * Returns an entry with ownership defaults resolved for transport.
+     */
+    public ErrorCatalogEntry resolveOwnership(String application) {
+        String resolvedOwner = isBlank(owner) ? application : owner;
+        ErrorCatalogScope resolvedScope = scope == null ? ErrorCatalogScope.APPLICATION : scope;
+        return new ErrorCatalogEntry(code, message, module, httpStatus, publicVisible,
+                deprecated, description, resolvedOwner, resolvedScope);
+    }
+
     private static boolean isBlank(String value) { return value == null || value.isBlank(); }
 }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogProvider.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogProvider.java
@@ -13,4 +13,15 @@ public interface ErrorCatalogProvider {
         List<ErrorCatalogEntry> entries = Arrays.stream(errorTypes).map(type -> ErrorCatalogEntry.from(type, module)).toList();
         return () -> entries;
     }
+
+    /**
+     * Declares framework-owned error codes shared by every application.
+     */
+    static ErrorCatalogProvider common(String owner, String module, ErrorType[] errorTypes) {
+        List<ErrorCatalogEntry> entries = Arrays.stream(errorTypes)
+                .map(type -> new ErrorCatalogEntry(type.getCode(), type.getMesg(), module,
+                        null, true, false, null, owner, ErrorCatalogScope.COMMON))
+                .toList();
+        return () -> entries;
+    }
 }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListener.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListener.java
@@ -39,8 +39,11 @@ public class ErrorCatalogRegistrationListener {
             if (entriesByCode.isEmpty()) return;
             String application = environment.getProperty("spring.application.name", "unknown-application");
             String token = environment.getProperty("opensabre.governance.error-catalog.registration-token", "");
+            List<ErrorCatalogEntry> resolvedEntries = entriesByCode.values().stream()
+                    .map(entry -> entry.resolveOwnership(application))
+                    .toList();
             clientProvider.getObject().registerErrorCatalog(new ErrorCatalogSnapshot(application,
-                    OpensabreVersion.getVersion(), List.copyOf(entriesByCode.values())), token);
+                    OpensabreVersion.getVersion(), resolvedEntries), token);
             log.info("Registered {} error catalog entries for {}", entriesByCode.size(), application);
         } catch (Exception exception) { log.warn("Error catalog registration failed; startup is unaffected", exception); }
     }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogScope.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogScope.java
@@ -1,0 +1,9 @@
+package io.github.opensabre.governance.errorcatalog;
+
+/**
+ * Defines whether an error-code declaration is shared or owned by one application.
+ */
+public enum ErrorCatalogScope {
+    COMMON,
+    APPLICATION
+}

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogProviderTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogProviderTest.java
@@ -13,4 +13,24 @@ class ErrorCatalogProviderTest {
         assertEquals("framework", entry.module());
         assertEquals(SystemErrorType.SYSTEM_ERROR.getMesg(), entry.message());
     }
+
+    @Test
+    void declaresFrameworkErrorsAsCommonDefinitions() {
+        ErrorCatalogEntry entry = ErrorCatalogProvider.common(
+                "opensabre-framework", "framework", SystemErrorType.values()).entries().iterator().next();
+
+        assertEquals("opensabre-framework", entry.owner());
+        assertEquals(ErrorCatalogScope.COMMON, entry.scope());
+    }
+
+    @Test
+    void resolvesApplicationOwnershipBeforeTransport() {
+        ErrorCatalogEntry entry = ErrorCatalogProvider.of(
+                "authorization", SystemErrorType.values()).entries().iterator().next();
+
+        ErrorCatalogEntry resolved = entry.resolveOwnership("base-authorization");
+
+        assertEquals("base-authorization", resolved.owner());
+        assertEquals(ErrorCatalogScope.APPLICATION, resolved.scope());
+    }
 }


### PR DESCRIPTION
## 变更
- ErrorCatalogEntry 增加 owner/scope 并保留旧构造器
- 系统错误码声明为 opensabre-framework/COMMON
- 业务错误码发送前解析为当前应用/APPLICATION
- 更新文档与测试

## 验证
- mvn -pl opensabre-starter-governance -am test
- mvn -pl opensabre-starter-governance test
- git diff --check