### PR TITLE
test: 补充错误码目录异步注册覆盖

### DIFF
--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListenerTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListenerTest.java
@@ -1,0 +1,77 @@
+package io.github.opensabre.governance.errorcatalog;
+
+import io.github.opensabre.governance.client.SysadminGovernanceClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mock.env.MockEnvironment;
+
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ErrorCatalogRegistrationListenerTest {
+
+    @Test
+    void registersResolvedSnapshotAfterApplicationIsReady() throws InterruptedException {
+        CountDownLatch registered = new CountDownLatch(1);
+        SysadminGovernanceClient client = client((snapshot, token) -> registered.countDown());
+        ErrorCatalogRegistrationListener listener = listener(client);
+
+        listener.register();
+
+        assertTrue(registered.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void remoteFailureDoesNotEscapeTheApplicationReadyListener() throws InterruptedException {
+        CountDownLatch attempted = new CountDownLatch(1);
+        SysadminGovernanceClient client = client((snapshot, token) -> {
+            attempted.countDown();
+            throw new IllegalStateException("sysadmin unavailable");
+        });
+        ErrorCatalogRegistrationListener listener = listener(client);
+
+        assertDoesNotThrow(listener::register);
+
+        assertTrue(attempted.await(5, TimeUnit.SECONDS));
+    }
+
+    private ErrorCatalogRegistrationListener listener(SysadminGovernanceClient client) {
+        ObjectProvider<SysadminGovernanceClient> clientProvider = new ObjectProvider<>() {
+            @Override
+            public SysadminGovernanceClient getObject() {
+                return client;
+            }
+        };
+        ErrorCatalogProvider provider = () -> List.of(
+                new ErrorCatalogEntry("DEMO-001", "Demo error", "demo", 400,
+                        true, false, null));
+        MockEnvironment environment = new MockEnvironment()
+                .withProperty("spring.application.name", "base-demo")
+                .withProperty("opensabre.governance.error-catalog.registration-token",
+                        "registration-secret");
+        return new ErrorCatalogRegistrationListener(clientProvider, List.of(provider), environment);
+    }
+
+    private SysadminGovernanceClient client(RegistrationCall registrationCall) {
+        return (SysadminGovernanceClient) Proxy.newProxyInstance(
+                SysadminGovernanceClient.class.getClassLoader(),
+                new Class<?>[]{SysadminGovernanceClient.class},
+                (proxy, method, arguments) -> {
+                    if ("registerErrorCatalog".equals(method.getName())) {
+                        registrationCall.invoke(
+                                (ErrorCatalogSnapshot) arguments[0], (String) arguments[1]);
+                    }
+                    return null;
+                });
+    }
+
+    @FunctionalInterface
+    private interface RegistrationCall {
+        void invoke(ErrorCatalogSnapshot snapshot, String token);
+    }
+}


### PR DESCRIPTION
变更：覆盖应用启动后错误码目录注册成功场景；覆盖 Sysadmin 不可用时注册失败不影响应用启动。\n\n验证：Framework Reactor 全部通过，错误码目录定向测试 5 个通过。\n\n关联：#42