### PR TITLE
release: 准备 Framework 0.7.1

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,12 +9,14 @@ jobs:
     # 任务的步骤
     steps:
       # 1. 声明 checkout 仓库代码到工作区
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       # 2. 安装Java 环境 这里会用到的参数就是 Git Action secrets中配置的，
     - name: Set up JDK 17
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 17
+        distribution: temurin
+        cache: maven
       # 3.编译打包
     - name: Build with Maven
       run: mvn -B package javadoc:javadoc --file pom.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,13 +13,15 @@ jobs:
     steps:
       # 1. 声明 checkout 仓库代码到工作区
       - name: Checkout Git Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       # 2. 安装Java 环境 这里会用到的参数就是 Git Action secrets中配置的，
       #    取值要在key前面加  secrets.
       - name: Set up Maven Central Repo
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: 17
+          distribution: temurin
+          cache: maven
           server-id: sonatype-nexus-staging
           server-username: ${{ secrets.OSSRH_USER }}
           server-password: ${{ secrets.OSSRH_PASSWORD }}

--- a/docs/modules/README.md
+++ b/docs/modules/README.md
@@ -23,4 +23,5 @@
 - [治理计次与限次接入](governance-usage.md)
 - [错误码目录](error-catalog.md)
 - [字典治理组件](dictionary.md)
+- [治理注册运行时](governance-registration.md)
 - [内部 Token 安全组件](security-internal-token.md)

--- a/docs/modules/dictionary.md
+++ b/docs/modules/dictionary.md
@@ -51,5 +51,6 @@ Framework 客户端约定：
 | `POST` | `/dicts/snapshots` | 携带 `X-Opensabre-Dictionary-Token` 注册应用字典快照 |
 | `GET` | `/dicts/{dictCode}/items/all` | 返回包含停用项的完整字典项列表 |
 
-截至 0.7.0 发布时，`base-sysadmin` 的当前发布分支仅提供字典 CRUD 与 options API，尚未实现以上两个治理协议端点。因此读取/注册链路在接入前必须先确认后端兼容版本；未补齐时保持 `registration-enabled=false`。
-跟踪 Issue：[https://github.com/opensabre/base-sysadmin/issues/10](https://github.com/opensabre/base-sysadmin/issues/10)
+`base-sysadmin` 0.7.1 已实现以上两个治理协议端点，并校验字典归属与注册凭据。
+Framework 与 Sysadmin 应同时升级到 0.7.1 后再开启 `registration-enabled`；
+混用旧版 Sysadmin 时保持为 `false`。

--- a/docs/modules/dictionary.md
+++ b/docs/modules/dictionary.md
@@ -15,6 +15,7 @@ opensabre:
 ```
 
 `registration-enabled` 默认关闭。只有后端实现字典快照注册协议后才可开启。
+0.7.1 起注册任务使用[治理注册运行时](governance-registration.md)执行有限重试并暴露运行状态。
 
 ## 声明与读取
 

--- a/docs/modules/error-catalog.md
+++ b/docs/modules/error-catalog.md
@@ -1,6 +1,8 @@
 # 错误码目录
 
-`opensabre-starter-governance` 会在应用完成启动后，异步上报基础错误码及应用声明的业务错误码。上报失败只记录日志，不影响应用可用性。
+`opensabre-starter-governance` 会在应用完成启动后，异步上报基础错误码及应用声明的业务错误码。
+0.7.1 起上报由[治理注册运行时](governance-registration.md)执行有限重试、指标和状态记录；
+失败不影响应用可用性。
 
 应用通过 `ErrorCatalogProvider` 声明业务枚举：
 

--- a/docs/modules/governance-registration.md
+++ b/docs/modules/governance-registration.md
@@ -1,0 +1,36 @@
+# 治理注册运行时
+
+Framework 0.7.1 统一调度错误码目录和字典快照注册。注册仍在应用就绪后异步执行；
+Sysadmin 暂时不可用不会阻塞应用启动，任务会按有限次数指数退避重试。
+
+```yaml
+opensabre:
+  governance:
+    registration:
+      max-attempts: 4
+      initial-backoff: 1s
+      max-backoff: 30s
+      jitter: 0.2
+      pool-size: 2
+      thread-name-prefix: governance-registration-
+      wait-for-tasks-to-complete-on-shutdown: true
+      await-termination: 35s
+```
+
+同一类型任务不会并发执行。应用关闭时由 Spring 管理注册调度器，并在
+`await-termination` 窗口内等待已接收和已安排重试的任务；超过窗口后关闭仍会继续，
+不会无限阻塞停机。每次尝试产生以下 Micrometer 指标：
+
+- `opensabre.governance.registration.attempts`，标签为 `task` 和 `result`
+- `opensabre.governance.registration.duration`，标签为 `task`
+
+Actuator 端点 `opensabreGovernanceRegistration` 提供最近一次开始、完成、成功、失败、
+下一次重试时间及累计次数。端点默认仍受 Spring Boot Actuator 暴露与安全配置控制：
+
+```http
+GET  /actuator/opensabreGovernanceRegistration
+POST /actuator/opensabreGovernanceRegistration?task=error-catalog
+POST /actuator/opensabreGovernanceRegistration?task=dictionary
+```
+
+写操作用于运维手动刷新；任务已运行或等待重试时不会重复提交。

--- a/docs/modules/security-internal-token.md
+++ b/docs/modules/security-internal-token.md
@@ -71,7 +71,7 @@ Token 是 `typ=OS-INTERNAL`、`alg=HS256` 的 compact JWS。核心字段包括�
 - `sub`、`username`：当前操作用户。
 - `jti`、`parent_jti`：本跳和上一跳 Token 标识。
 - `iat`、`nbf`、`exp`：有效期，硬上限 120 秒。
-- `scope`、`roles`：授权快照。
+- `scope`、`roles`、`authorities`：分别表示 Scope、Spring Security 角色和非角色直接 Authority 快照。
 - `hop`：调用跳数。
 - `trace_id`：链路标识。
 - `key_config_version`：共享密钥配置版本。

--- a/docs/modules/security-internal-token.md
+++ b/docs/modules/security-internal-token.md
@@ -153,15 +153,28 @@ SecurityFilterChain securityFilterChain(
 }
 ```
 
-过滤器把内部 Token 的 `roles` 原样映射为 Authority，把 `scopes` 映射为
-`SCOPE_<scope>`，并同步绑定 `UserContextHolder`。外部 Bearer JWT 和内部 Token
+过滤器把内部 Token 的 `roles` 视为 Spring Security 角色：无前缀值（包括 0.7.0
+签发的 Token）会补为 `ROLE_`，已有 `ROLE_` 前缀则保持不变。因此应用应使用
+`hasRole("ADMIN")` 或 `hasAuthority("ROLE_ADMIN")`；此前使用
+`hasAuthority("ADMIN")` 的应用需要迁移。`scopes` 映射为 `SCOPE_<scope>`，
+其他非角色 Authority 通过独立的 `authorities` claim 原值传递，因此
+`hasAuthority("ORDER_WRITE")` 可跨服务保持一致。接收端同时绑定
+`UserContextHolder`。外部 Bearer JWT 和内部 Token
 不能同时出现在同一请求中：网关到首应用只携带外部 JWT，后续服务调用只携带逐跳
 重签的 `x-client-token`。
+
+滚动升级说明：0.7.0 可以校验带 `authorities` 的 0.7.1 Token，但 0.7.0
+中间服务重签时不会继续携带该新 claim。依赖直接 Authority 的调用链应先将所有
+负责重签的中间服务升级到 0.7.1；角色和 scope 不受此限制。
 
 Starter 会关闭该过滤器的独立 Servlet 自动注册，避免它运行在 Spring Security
 上下文生命周期之外；没有 `SecurityFilterChain` 的应用仍由 MVC 拦截器完成验证。
 
 ## Feign 逐跳重签
+
+内部 Token 签名拦截器在 Spring Bean 类型的 Feign 拦截器中最后执行，并在签名前清理
+`Authorization`、`x-client-token` 与 `x-client-token-user`。应用自定义拦截器必须排在
+签名拦截器之前；不要通过 Feign 属性默认 Header 或后置拦截器再次添加这些受管凭证。
 
 `opensabre-starter-rpc` 引入安全 Starter。每次 Feign 调用都会：
 

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/GovernanceProperties.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/GovernanceProperties.java
@@ -3,6 +3,8 @@ package io.github.opensabre.governance.config;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 @Data
 @ConfigurationProperties(prefix = "opensabre.governance")
 public class GovernanceProperties {
@@ -18,6 +20,7 @@ public class GovernanceProperties {
     private Usage usage = new Usage();
     private ErrorCatalog errorCatalog = new ErrorCatalog();
     private Dictionary dictionary = new Dictionary();
+    private Registration registration = new Registration();
 
     @Data
     public static class Sysadmin {
@@ -66,6 +69,21 @@ public class GovernanceProperties {
         private boolean registrationEnabled = false;
         private String registrationToken = "";
         private java.util.List<String> preloadCodes = java.util.List.of();
+    }
+
+    /**
+     * Shared runtime policy for best-effort governance registration tasks.
+     */
+    @Data
+    public static class Registration {
+        private int maxAttempts = 4;
+        private Duration initialBackoff = Duration.ofSeconds(1);
+        private Duration maxBackoff = Duration.ofSeconds(30);
+        private double jitter = 0.2d;
+        private int poolSize = 2;
+        private String threadNamePrefix = "governance-registration-";
+        private boolean waitForTasksToCompleteOnShutdown = true;
+        private Duration awaitTermination = Duration.ofSeconds(35);
     }
 
     public enum Transport { HTTP, EDA }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/OpensabreGovernanceConfig.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/OpensabreGovernanceConfig.java
@@ -13,6 +13,8 @@ import io.github.opensabre.governance.dictionary.DictionaryRegistrationListener;
 import io.github.opensabre.governance.dictionary.DictionaryService;
 import io.github.opensabre.governance.dictionary.JetCacheDictionaryService;
 import io.github.opensabre.governance.dictionary.DictionaryPreloadListener;
+import io.github.opensabre.governance.registration.GovernanceRegistrationCoordinator;
+import io.github.opensabre.governance.registration.GovernanceRegistrationEndpoint;
 import com.alicp.jetcache.CacheManager;
 import io.github.opensabre.governance.ratelimit.aspect.RateLimitAspect;
 import io.github.opensabre.governance.ratelimit.GovernanceRateLimiter;
@@ -26,8 +28,11 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import io.github.opensabre.common.core.exception.SystemErrorType;
 import java.util.List;
+import java.util.Map;
 
 @AutoConfiguration
 @EnableFeignClients(basePackageClasses = SysadminGovernanceClient.class)
@@ -35,6 +40,30 @@ import java.util.List;
 @PropertySource(value = "classpath:opensabre-governance.yml", encoding = "UTF8", factory = YamlPropertyLoaderFactory.class)
 @ConditionalOnProperty(prefix = "opensabre.governance", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class OpensabreGovernanceConfig {
+
+    @Bean("governanceRegistrationScheduler")
+    @ConditionalOnMissingBean(name = "governanceRegistrationScheduler")
+    public ThreadPoolTaskScheduler governanceRegistrationScheduler(GovernanceProperties properties) {
+        GovernanceProperties.Registration registration = properties.getRegistration();
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(registration.getPoolSize());
+        scheduler.setThreadNamePrefix(registration.getThreadNamePrefix());
+        scheduler.setWaitForTasksToCompleteOnShutdown(registration.isWaitForTasksToCompleteOnShutdown());
+        scheduler.setAwaitTerminationSeconds((int) registration.getAwaitTermination().toSeconds());
+        scheduler.setRemoveOnCancelPolicy(true);
+        return scheduler;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GovernanceRegistrationCoordinator governanceRegistrationCoordinator(
+            @Qualifier("governanceRegistrationScheduler")
+            ThreadPoolTaskScheduler governanceRegistrationScheduler,
+            GovernanceProperties properties,
+            ObjectProvider<io.micrometer.core.instrument.MeterRegistry> meterRegistryProvider) {
+        return new GovernanceRegistrationCoordinator(
+                governanceRegistrationScheduler, properties, meterRegistryProvider);
+    }
 
     @Bean
     @ConditionalOnMissingBean
@@ -94,8 +123,10 @@ public class OpensabreGovernanceConfig {
     @Bean
     @ConditionalOnProperty(prefix = "opensabre.governance.error-catalog", name = "enabled", havingValue = "true", matchIfMissing = true)
     public ErrorCatalogRegistrationListener errorCatalogRegistrationListener(ObjectProvider<SysadminGovernanceClient> clientProvider,
-            List<ErrorCatalogProvider> providers, org.springframework.core.env.Environment environment) {
-        return new ErrorCatalogRegistrationListener(clientProvider, providers, environment);
+            List<ErrorCatalogProvider> providers, org.springframework.core.env.Environment environment,
+            GovernanceRegistrationCoordinator registrationCoordinator) {
+        return new ErrorCatalogRegistrationListener(
+                clientProvider, providers, environment, registrationCoordinator);
     }
 
     @Bean
@@ -104,8 +135,28 @@ public class OpensabreGovernanceConfig {
     public DictionaryRegistrationListener dictionaryRegistrationListener(
             ObjectProvider<SysadminGovernanceClient> clientProvider,
             List<DictionaryProvider> providers,
-            org.springframework.core.env.Environment environment) {
-        return new DictionaryRegistrationListener(clientProvider, providers, environment);
+            org.springframework.core.env.Environment environment,
+            GovernanceRegistrationCoordinator registrationCoordinator) {
+        return new DictionaryRegistrationListener(
+                clientProvider, providers, environment, registrationCoordinator);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public GovernanceRegistrationEndpoint governanceRegistrationEndpoint(
+            GovernanceRegistrationCoordinator coordinator,
+            ObjectProvider<ErrorCatalogRegistrationListener> errorCatalogListener,
+            ObjectProvider<DictionaryRegistrationListener> dictionaryListener) {
+        Map<String, Runnable> triggers = new java.util.LinkedHashMap<>();
+        ErrorCatalogRegistrationListener errorCatalog = errorCatalogListener.getIfAvailable();
+        DictionaryRegistrationListener dictionary = dictionaryListener.getIfAvailable();
+        if (errorCatalog != null) {
+            triggers.put("error-catalog", errorCatalog::register);
+        }
+        if (dictionary != null) {
+            triggers.put("dictionary", dictionary::register);
+        }
+        return new GovernanceRegistrationEndpoint(coordinator, Map.copyOf(triggers));
     }
 
     @Bean

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryRegistrationListener.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryRegistrationListener.java
@@ -1,6 +1,7 @@
 package io.github.opensabre.governance.dictionary;
 
 import io.github.opensabre.governance.client.SysadminGovernanceClient;
+import io.github.opensabre.governance.registration.GovernanceRegistrationCoordinator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -12,7 +13,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * 应用就绪后尽力注册字典，sysadmin 不可用不会阻塞应用启动。
@@ -24,14 +24,14 @@ public class DictionaryRegistrationListener {
     private final ObjectProvider<SysadminGovernanceClient> clientProvider;
     private final List<DictionaryProvider> providers;
     private final Environment environment;
+    private final GovernanceRegistrationCoordinator registrationCoordinator;
 
     @EventListener(ApplicationReadyEvent.class)
     public void register() {
-        CompletableFuture.runAsync(this::registerSafely);
+        registrationCoordinator.submit("dictionary", this::registerOnce);
     }
 
-    private void registerSafely() {
-        try {
+    private void registerOnce() {
             Map<String, DictionaryDefinition> definitions = new LinkedHashMap<>();
             for (DictionaryProvider provider : providers) {
                 Collection<DictionaryDefinition> provided = provider.dictionaries();
@@ -41,8 +41,8 @@ public class DictionaryRegistrationListener {
                 for (DictionaryDefinition definition : provided) {
                     DictionaryDefinition previous = definitions.putIfAbsent(definition.dictCode(), definition);
                     if (previous != null && !previous.equals(definition)) {
-                        log.error("Skip dictionary registration: code {} conflicts locally", definition.dictCode());
-                        return;
+                        throw new IllegalStateException(
+                                "Dictionary code conflicts locally: " + definition.dictCode());
                     }
                 }
             }
@@ -54,8 +54,5 @@ public class DictionaryRegistrationListener {
             clientProvider.getObject().registerDictionaries(
                     DictionarySnapshot.from(application, List.copyOf(definitions.values())), token);
             log.info("Registered {} dictionaries for {}", definitions.size(), application);
-        } catch (Exception exception) {
-            log.warn("Dictionary registration failed; startup is unaffected", exception);
-        }
     }
 }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListener.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListener.java
@@ -2,6 +2,7 @@ package io.github.opensabre.governance.errorcatalog;
 
 import io.github.opensabre.boot.metadata.OpensabreVersion;
 import io.github.opensabre.governance.client.SysadminGovernanceClient;
+import io.github.opensabre.governance.registration.GovernanceRegistrationCoordinator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -12,7 +13,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 
 /** Best-effort post-startup catalog registration; Sysadmin downtime never blocks the application. */
 @Slf4j
@@ -21,10 +21,13 @@ public class ErrorCatalogRegistrationListener {
     private final ObjectProvider<SysadminGovernanceClient> clientProvider;
     private final List<ErrorCatalogProvider> providers;
     private final Environment environment;
+    private final GovernanceRegistrationCoordinator registrationCoordinator;
     @EventListener(ApplicationReadyEvent.class)
-    public void register() { CompletableFuture.runAsync(this::registerSafely); }
-    private void registerSafely() {
-        try {
+    public void register() {
+        registrationCoordinator.submit("error-catalog", this::registerOnce);
+    }
+
+    private void registerOnce() {
             Map<String, ErrorCatalogEntry> entriesByCode = new LinkedHashMap<>();
             for (ErrorCatalogProvider provider : providers) {
                 Collection<ErrorCatalogEntry> entries = provider.entries();
@@ -32,7 +35,8 @@ public class ErrorCatalogRegistrationListener {
                 for (ErrorCatalogEntry entry : entries) {
                     ErrorCatalogEntry previous = entriesByCode.putIfAbsent(entry.code(), entry);
                     if (previous != null && !previous.equals(entry)) {
-                        log.error("Skip error catalog registration: code {} conflicts locally", entry.code()); return;
+                        throw new IllegalStateException(
+                                "Error catalog code conflicts locally: " + entry.code());
                     }
                 }
             }
@@ -45,6 +49,5 @@ public class ErrorCatalogRegistrationListener {
             clientProvider.getObject().registerErrorCatalog(new ErrorCatalogSnapshot(application,
                     OpensabreVersion.getVersion(), resolvedEntries), token);
             log.info("Registered {} error catalog entries for {}", entriesByCode.size(), application);
-        } catch (Exception exception) { log.warn("Error catalog registration failed; startup is unaffected", exception); }
     }
 }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/registration/GovernanceRegistrationCoordinator.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/registration/GovernanceRegistrationCoordinator.java
@@ -1,0 +1,263 @@
+package io.github.opensabre.governance.registration;
+
+import io.github.opensabre.governance.config.GovernanceProperties;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.scheduling.TaskScheduler;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Runs governance registration on a managed scheduler with bounded exponential retry.
+ */
+@Slf4j
+public class GovernanceRegistrationCoordinator {
+
+    private final TaskScheduler scheduler;
+    private final GovernanceProperties.Registration properties;
+    private final MeterRegistry meterRegistry;
+    private final Clock clock;
+    private final Map<String, TaskState> states = new ConcurrentHashMap<>();
+
+    public GovernanceRegistrationCoordinator(
+            TaskScheduler scheduler,
+            GovernanceProperties properties,
+            ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this(scheduler, properties.getRegistration(), meterRegistryProvider.getIfAvailable(), Clock.systemUTC());
+    }
+
+    GovernanceRegistrationCoordinator(
+            TaskScheduler scheduler,
+            GovernanceProperties.Registration properties,
+            MeterRegistry meterRegistry,
+            Clock clock) {
+        this.scheduler = scheduler;
+        this.properties = properties;
+        this.meterRegistry = meterRegistry;
+        this.clock = clock;
+        validate(properties);
+    }
+
+    /**
+     * Starts a registration cycle unless the same task is already running or waiting to retry.
+     *
+     * @param taskName stable task identifier used in logs and metrics
+     * @param action registration call that throws when the attempt fails
+     * @return {@code true} when a new cycle was accepted
+     */
+    public boolean submit(String taskName, Runnable action) {
+        TaskState state = states.computeIfAbsent(taskName, ignored -> new TaskState(taskName));
+        if (!state.inFlight.compareAndSet(false, true)) {
+            log.debug("Skip overlapping governance registration task: task={}", taskName);
+            return false;
+        }
+        state.beginCycle();
+        scheduleSafely(taskName, action, state, 1, Duration.ZERO);
+        return true;
+    }
+
+    /**
+     * Returns a stable snapshot suitable for actuator and diagnostics.
+     */
+    public Map<String, GovernanceRegistrationStatus> statuses() {
+        Map<String, GovernanceRegistrationStatus> snapshot = new LinkedHashMap<>();
+        states.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .forEach(entry -> snapshot.put(entry.getKey(), entry.getValue().snapshot()));
+        return snapshot;
+    }
+
+    private void scheduleSafely(
+            String taskName,
+            Runnable action,
+            TaskState state,
+            int attempt,
+            Duration delay) {
+        Instant scheduledAt = clock.instant().plus(delay);
+        state.scheduled(attempt, scheduledAt, delay.isZero());
+        try {
+            scheduler.schedule(() -> runAttempt(taskName, action, state, attempt), scheduledAt);
+        } catch (RuntimeException exception) {
+            state.schedulingRejected(clock.instant(), exception);
+            count(taskName, "rejected");
+            log.warn(
+                    "Governance registration task could not be scheduled; startup is unaffected: task={}",
+                    taskName, exception);
+        }
+    }
+
+    private void runAttempt(String taskName, Runnable action, TaskState state, int attempt) {
+        Instant startedAt = clock.instant();
+        state.running(attempt, startedAt);
+        Timer.Sample timer = meterRegistry == null ? null : Timer.start(meterRegistry);
+        try {
+            action.run();
+            state.succeeded(clock.instant());
+            count(taskName, "success");
+            log.info("Governance registration task succeeded: task={}, attempt={}", taskName, attempt);
+        } catch (Exception exception) {
+            Instant failedAt = clock.instant();
+            state.failedAttempt(failedAt, exception);
+            count(taskName, "failure");
+            if (attempt < properties.getMaxAttempts()) {
+                Duration delay = retryDelay(attempt);
+                log.warn(
+                        "Governance registration task failed; retry scheduled: task={}, attempt={}, delay={}",
+                        taskName, attempt, delay, exception);
+                scheduleSafely(taskName, action, state, attempt + 1, delay);
+            } else {
+                state.exhausted();
+                log.warn(
+                        "Governance registration task failed after all attempts: task={}, attempts={}",
+                        taskName, attempt, exception);
+            }
+        } finally {
+            if (timer != null) {
+                timer.stop(Timer.builder("opensabre.governance.registration.duration")
+                        .description("Governance registration attempt duration")
+                        .tag("task", taskName)
+                        .register(meterRegistry));
+            }
+        }
+    }
+
+    private Duration retryDelay(int failedAttempt) {
+        long initialMillis = properties.getInitialBackoff().toMillis();
+        long maximumMillis = properties.getMaxBackoff().toMillis();
+        long exponential;
+        try {
+            exponential = Math.multiplyExact(initialMillis, 1L << Math.min(failedAttempt - 1, 30));
+        } catch (ArithmeticException exception) {
+            exponential = maximumMillis;
+        }
+        long capped = Math.min(exponential, maximumMillis);
+        double jitter = properties.getJitter();
+        double jitterFactor = jitter == 0.0d
+                ? 1.0d
+                : 1.0d + ThreadLocalRandom.current().nextDouble(-jitter, jitter);
+        return Duration.ofMillis(Math.max(0L, Math.round(capped * jitterFactor)));
+    }
+
+    private void count(String taskName, String result) {
+        if (meterRegistry != null) {
+            Counter.builder("opensabre.governance.registration.attempts")
+                    .description("Governance registration attempts")
+                    .tag("task", taskName)
+                    .tag("result", result)
+                    .register(meterRegistry)
+                    .increment();
+        }
+    }
+
+    private static void validate(GovernanceProperties.Registration properties) {
+        if (properties.getMaxAttempts() < 1) {
+            throw new IllegalArgumentException("registration.max-attempts must be at least 1");
+        }
+        if (properties.getInitialBackoff().isNegative()
+                || properties.getMaxBackoff().compareTo(properties.getInitialBackoff()) < 0) {
+            throw new IllegalArgumentException("registration backoff configuration is invalid");
+        }
+        if (properties.getJitter() < 0.0d || properties.getJitter() > 1.0d) {
+            throw new IllegalArgumentException("registration.jitter must be between 0 and 1");
+        }
+        if (properties.getPoolSize() < 1) {
+            throw new IllegalArgumentException("registration.pool-size must be at least 1");
+        }
+        if (properties.getAwaitTermination().isNegative()) {
+            throw new IllegalArgumentException("registration.await-termination must not be negative");
+        }
+    }
+
+    private static final class TaskState {
+        private final String taskName;
+        private final AtomicBoolean inFlight = new AtomicBoolean();
+        private GovernanceRegistrationStatus.State state = GovernanceRegistrationStatus.State.IDLE;
+        private int attempt;
+        private long successes;
+        private long failures;
+        private Instant lastStartedAt;
+        private Instant lastCompletedAt;
+        private Instant lastSuccessAt;
+        private Instant lastFailureAt;
+        private Instant nextRetryAt;
+        private long lastDurationMillis;
+        private String lastError;
+
+        private TaskState(String taskName) {
+            this.taskName = taskName;
+        }
+
+        private synchronized void beginCycle() {
+            attempt = 0;
+            nextRetryAt = null;
+            lastError = null;
+        }
+
+        private synchronized void scheduled(int attempt, Instant scheduledAt, boolean immediate) {
+            this.attempt = attempt;
+            this.state = immediate
+                    ? GovernanceRegistrationStatus.State.RUNNING
+                    : GovernanceRegistrationStatus.State.RETRY_SCHEDULED;
+            this.nextRetryAt = immediate ? null : scheduledAt;
+        }
+
+        private synchronized void running(int attempt, Instant startedAt) {
+            this.attempt = attempt;
+            this.state = GovernanceRegistrationStatus.State.RUNNING;
+            this.lastStartedAt = startedAt;
+            this.nextRetryAt = null;
+        }
+
+        private synchronized void succeeded(Instant completedAt) {
+            this.state = GovernanceRegistrationStatus.State.SUCCEEDED;
+            this.successes++;
+            this.lastCompletedAt = completedAt;
+            this.lastSuccessAt = completedAt;
+            this.lastDurationMillis = durationMillis(completedAt);
+            this.lastError = null;
+            this.inFlight.set(false);
+        }
+
+        private synchronized void failedAttempt(Instant failedAt, Exception exception) {
+            this.failures++;
+            this.lastCompletedAt = failedAt;
+            this.lastFailureAt = failedAt;
+            this.lastDurationMillis = durationMillis(failedAt);
+            // The actuator view never exposes backend response text or credentials.
+            this.lastError = exception.getClass().getSimpleName();
+        }
+
+        private synchronized void exhausted() {
+            this.state = GovernanceRegistrationStatus.State.FAILED;
+            this.nextRetryAt = null;
+            this.inFlight.set(false);
+        }
+
+        private synchronized void schedulingRejected(Instant failedAt, RuntimeException exception) {
+            failedAttempt(failedAt, exception);
+            this.state = GovernanceRegistrationStatus.State.FAILED;
+            this.nextRetryAt = null;
+            this.inFlight.set(false);
+        }
+
+        private long durationMillis(Instant completedAt) {
+            return lastStartedAt == null ? 0L : Math.max(0L, Duration.between(lastStartedAt, completedAt).toMillis());
+        }
+
+        private synchronized GovernanceRegistrationStatus snapshot() {
+            return new GovernanceRegistrationStatus(
+                    taskName, state, attempt, successes, failures, lastStartedAt, lastCompletedAt,
+                    lastSuccessAt, lastFailureAt, nextRetryAt, lastDurationMillis, lastError);
+        }
+    }
+}

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/registration/GovernanceRegistrationEndpoint.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/registration/GovernanceRegistrationEndpoint.java
@@ -1,0 +1,45 @@
+package io.github.opensabre.governance.registration;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+
+import java.util.Map;
+
+/**
+ * Actuator endpoint exposing governance registration status.
+ */
+@Endpoint(id = "opensabreGovernanceRegistration")
+public class GovernanceRegistrationEndpoint {
+
+    private final GovernanceRegistrationCoordinator coordinator;
+    private final Map<String, Runnable> triggers;
+
+    public GovernanceRegistrationEndpoint(
+            GovernanceRegistrationCoordinator coordinator,
+            Map<String, Runnable> triggers) {
+        this.coordinator = coordinator;
+        this.triggers = triggers;
+    }
+
+    /**
+     * Returns the latest status for all known registration tasks.
+     */
+    @ReadOperation
+    public Map<String, GovernanceRegistrationStatus> status() {
+        return coordinator.statuses();
+    }
+
+    /**
+     * Triggers one registration task without allowing overlap.
+     */
+    @WriteOperation
+    public Map<String, GovernanceRegistrationStatus> trigger(String task) {
+        Runnable trigger = triggers.get(task);
+        if (trigger == null) {
+            throw new IllegalArgumentException("Unknown governance registration task: " + task);
+        }
+        trigger.run();
+        return coordinator.statuses();
+    }
+}

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/registration/GovernanceRegistrationStatus.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/registration/GovernanceRegistrationStatus.java
@@ -1,0 +1,32 @@
+package io.github.opensabre.governance.registration;
+
+import java.time.Instant;
+
+/**
+ * Immutable operational view of one governance registration task.
+ */
+public record GovernanceRegistrationStatus(
+        String task,
+        State state,
+        int attempt,
+        long successes,
+        long failures,
+        Instant lastStartedAt,
+        Instant lastCompletedAt,
+        Instant lastSuccessAt,
+        Instant lastFailureAt,
+        Instant nextRetryAt,
+        long lastDurationMillis,
+        String lastError) {
+
+    /**
+     * Registration lifecycle exposed through the actuator endpoint.
+     */
+    public enum State {
+        IDLE,
+        RUNNING,
+        RETRY_SCHEDULED,
+        SUCCEEDED,
+        FAILED
+    }
+}

--- a/opensabre-starter-governance/src/main/resources/opensabre-governance.yml
+++ b/opensabre-starter-governance/src/main/resources/opensabre-governance.yml
@@ -3,6 +3,15 @@ opensabre:
     enabled: true
     sysadmin:
       service-id: base-sysadmin
+    registration:
+      max-attempts: 4
+      initial-backoff: 1s
+      max-backoff: 30s
+      jitter: 0.2
+      pool-size: 2
+      thread-name-prefix: governance-registration-
+      wait-for-tasks-to-complete-on-shutdown: true
+      await-termination: 35s
     audit:
       enabled: true
       async:

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/registration/GovernanceRegistrationCoordinatorTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/registration/GovernanceRegistrationCoordinatorTest.java
@@ -1,0 +1,154 @@
+package io.github.opensabre.governance.registration;
+
+import io.github.opensabre.governance.config.GovernanceProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.core.task.TaskRejectedException;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class GovernanceRegistrationCoordinatorTest {
+
+    private final ThreadPoolTaskScheduler scheduler = scheduler();
+
+    @AfterEach
+    void shutdownScheduler() {
+        scheduler.shutdown();
+    }
+
+    @Test
+    void retriesUntilRegistrationSucceedsAndExposesStatus() throws Exception {
+        GovernanceProperties.Registration properties = properties(3);
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        GovernanceRegistrationCoordinator coordinator = new GovernanceRegistrationCoordinator(
+                scheduler, properties, meterRegistry, Clock.systemUTC());
+        AtomicInteger attempts = new AtomicInteger();
+        CountDownLatch completed = new CountDownLatch(1);
+
+        assertThat(coordinator.submit("error-catalog", () -> {
+            if (attempts.incrementAndGet() < 3) {
+                throw new IllegalStateException("sysadmin unavailable");
+            }
+            completed.countDown();
+        })).isTrue();
+
+        assertThat(completed.await(2, TimeUnit.SECONDS)).isTrue();
+        awaitState(coordinator, "error-catalog", GovernanceRegistrationStatus.State.SUCCEEDED);
+        GovernanceRegistrationStatus status = coordinator.statuses().get("error-catalog");
+        assertThat(status.attempt()).isEqualTo(3);
+        assertThat(status.successes()).isEqualTo(1);
+        assertThat(status.failures()).isEqualTo(2);
+        assertThat(status.lastError()).isNull();
+        assertThat(meterRegistry.get("opensabre.governance.registration.attempts")
+                .tag("task", "error-catalog")
+                .tag("result", "success")
+                .counter().count()).isEqualTo(1.0d);
+    }
+
+    @Test
+    void exhaustsBoundedAttemptsWithoutBlockingCaller() throws Exception {
+        GovernanceRegistrationCoordinator coordinator = new GovernanceRegistrationCoordinator(
+                scheduler, properties(2), null, Clock.systemUTC());
+        AtomicInteger attempts = new AtomicInteger();
+
+        assertThat(coordinator.submit("dictionary", () -> {
+            attempts.incrementAndGet();
+            throw new IllegalStateException("sysadmin unavailable");
+        })).isTrue();
+
+        awaitState(coordinator, "dictionary", GovernanceRegistrationStatus.State.FAILED);
+        assertThat(attempts).hasValue(2);
+        assertThat(coordinator.statuses().get("dictionary").failures()).isEqualTo(2);
+    }
+
+    @Test
+    void rejectsOverlappingRegistrationCycles() throws Exception {
+        GovernanceRegistrationCoordinator coordinator = new GovernanceRegistrationCoordinator(
+                scheduler, properties(1), null, Clock.systemUTC());
+        CountDownLatch running = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+
+        assertThat(coordinator.submit("dictionary", () -> {
+            running.countDown();
+            try {
+                release.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(exception);
+            }
+        })).isTrue();
+        assertThat(running.await(2, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(coordinator.submit("dictionary", () -> {
+        })).isFalse();
+        release.countDown();
+        awaitState(coordinator, "dictionary", GovernanceRegistrationStatus.State.SUCCEEDED);
+    }
+
+    @Test
+    void releasesTaskAndRecordsMetricWhenSchedulingIsRejected() {
+        TaskScheduler rejectingScheduler = mock(TaskScheduler.class);
+        when(rejectingScheduler.schedule(any(Runnable.class), any(java.time.Instant.class)))
+                .thenThrow(new TaskRejectedException("scheduler stopped"));
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        GovernanceRegistrationCoordinator coordinator = new GovernanceRegistrationCoordinator(
+                rejectingScheduler, properties(1), meterRegistry, Clock.systemUTC());
+
+        assertThat(coordinator.submit("dictionary", () -> {
+        })).isTrue();
+        assertThat(coordinator.statuses().get("dictionary").state())
+                .isEqualTo(GovernanceRegistrationStatus.State.FAILED);
+        assertThat(coordinator.statuses().get("dictionary").lastError())
+                .isEqualTo("TaskRejectedException");
+        assertThat(coordinator.submit("dictionary", () -> {
+        })).isTrue();
+        assertThat(meterRegistry.get("opensabre.governance.registration.attempts")
+                .tag("task", "dictionary")
+                .tag("result", "rejected")
+                .counter().count()).isEqualTo(2.0d);
+    }
+
+    private static void awaitState(
+            GovernanceRegistrationCoordinator coordinator,
+            String task,
+            GovernanceRegistrationStatus.State expected) throws InterruptedException {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+        while (System.nanoTime() < deadline) {
+            GovernanceRegistrationStatus status = coordinator.statuses().get(task);
+            if (status != null && status.state() == expected) {
+                return;
+            }
+            Thread.sleep(10L);
+        }
+        assertThat(coordinator.statuses().get(task).state()).isEqualTo(expected);
+    }
+
+    private static GovernanceProperties.Registration properties(int maxAttempts) {
+        GovernanceProperties.Registration properties = new GovernanceProperties.Registration();
+        properties.setMaxAttempts(maxAttempts);
+        properties.setInitialBackoff(Duration.ofMillis(1));
+        properties.setMaxBackoff(Duration.ofMillis(1));
+        properties.setJitter(0.0d);
+        return properties;
+    }
+
+    private static ThreadPoolTaskScheduler scheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("governance-registration-test-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/registration/GovernanceRegistrationEndpointTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/registration/GovernanceRegistrationEndpointTest.java
@@ -1,0 +1,63 @@
+package io.github.opensabre.governance.registration;
+
+import io.github.opensabre.governance.config.GovernanceProperties;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GovernanceRegistrationEndpointTest {
+
+    private final ThreadPoolTaskScheduler scheduler = scheduler();
+
+    @AfterEach
+    void shutdownScheduler() {
+        scheduler.shutdown();
+    }
+
+    @Test
+    void triggersKnownTaskAndReturnsItsStatus() throws Exception {
+        GovernanceRegistrationCoordinator coordinator = new GovernanceRegistrationCoordinator(
+                scheduler,
+                new GovernanceProperties(),
+                new StaticListableBeanFactory().getBeanProvider(io.micrometer.core.instrument.MeterRegistry.class));
+        CountDownLatch completed = new CountDownLatch(1);
+        GovernanceRegistrationEndpoint endpoint = new GovernanceRegistrationEndpoint(
+                coordinator,
+                Map.of("dictionary", () -> coordinator.submit("dictionary", completed::countDown)));
+
+        endpoint.trigger("dictionary");
+
+        assertThat(completed.await(2, TimeUnit.SECONDS)).isTrue();
+        assertThat(endpoint.status()).containsKey("dictionary");
+    }
+
+    @Test
+    void rejectsUnknownTask() {
+        GovernanceRegistrationCoordinator coordinator = new GovernanceRegistrationCoordinator(
+                scheduler,
+                new GovernanceProperties(),
+                new StaticListableBeanFactory().getBeanProvider(io.micrometer.core.instrument.MeterRegistry.class));
+        GovernanceRegistrationEndpoint endpoint =
+                new GovernanceRegistrationEndpoint(coordinator, Map.of());
+
+        assertThatThrownBy(() -> endpoint.trigger("unknown"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown");
+    }
+
+    private static ThreadPoolTaskScheduler scheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("governance-registration-endpoint-test-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}

--- a/opensabre-starter-rpc/src/main/java/io/github/opensabre/rpc/openfeign/interceptor/FeignInternalTokenInterceptor.java
+++ b/opensabre-starter-rpc/src/main/java/io/github/opensabre/rpc/openfeign/interceptor/FeignInternalTokenInterceptor.java
@@ -8,13 +8,18 @@ import io.github.opensabre.security.token.InternalTokenConstants;
 import io.github.opensabre.security.token.InternalTokenRequestFactory;
 import io.github.opensabre.security.token.InternalTokenService;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.Ordered;
 
 import java.util.ArrayList;
+import java.util.Set;
 
 /**
  * Re-signs an internal token for every Feign service hop.
  */
-public class FeignInternalTokenInterceptor implements RequestInterceptor {
+public class FeignInternalTokenInterceptor implements RequestInterceptor, Ordered {
+
+    private static final Set<String> MANAGED_CREDENTIAL_HEADERS = Set.of(
+            "authorization", "x-client-token", "x-client-token-user");
 
     private final InternalTokenService tokenService;
     private final InternalTokenRequestFactory requestFactory;
@@ -34,13 +39,12 @@ public class FeignInternalTokenInterceptor implements RequestInterceptor {
 
     @Override
     public void apply(RequestTemplate template) {
-        // Never forward a caller-provided token unchanged.
-        new ArrayList<>(template.headers().keySet()).stream()
-                .filter(name -> InternalTokenConstants.HEADER.equalsIgnoreCase(name))
-                .forEach(template::removeHeader);
         if (!properties.isEnabled()) {
+            removeHeaders(template, Set.of("x-client-token", "x-client-token-user"));
             return;
         }
+        // Remove every managed credential immediately before signing the next service hop.
+        removeHeaders(template, MANAGED_CREDENTIAL_HEADERS);
         Target<?> target = template.feignTarget();
         if (target == null || !hasText(target.name())) {
             throw new IllegalStateException("Feign target service name is required for internal token signing");
@@ -50,6 +54,20 @@ public class FeignInternalTokenInterceptor implements RequestInterceptor {
         }
         String token = tokenService.issue(requestFactory.create(applicationName, target.name()));
         template.header(InternalTokenConstants.HEADER, token);
+    }
+
+    private static void removeHeaders(RequestTemplate template, Set<String> headerNames) {
+        new ArrayList<>(template.headers().keySet()).stream()
+                .filter(name -> headerNames.stream().anyMatch(candidate -> candidate.equalsIgnoreCase(name)))
+                .forEach(template::removeHeader);
+    }
+
+    /**
+     * Runs after regular Feign interceptors so caller credentials are removed just before signing.
+     */
+    @Override
+    public int getOrder() {
+        return Ordered.LOWEST_PRECEDENCE;
     }
 
     private static boolean hasText(String value) {

--- a/opensabre-starter-rpc/src/test/java/io/github/opensabre/rpc/openfeign/interceptor/FeignInternalTokenInterceptorTest.java
+++ b/opensabre-starter-rpc/src/test/java/io/github/opensabre/rpc/openfeign/interceptor/FeignInternalTokenInterceptorTest.java
@@ -1,6 +1,7 @@
 package io.github.opensabre.rpc.openfeign.interceptor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import feign.Target;
 import io.github.opensabre.common.core.util.UserContextHolder;
@@ -14,16 +15,20 @@ import io.github.opensabre.security.token.InternalTokenRequestFactory;
 import io.github.opensabre.security.token.InternalTokenService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.core.Ordered;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.ArrayList;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FeignInternalTokenInterceptorTest {
 
@@ -69,10 +74,58 @@ class FeignInternalTokenInterceptorTest {
                 new InternalTokenRequestFactory(context), properties, "base-middle");
         RequestTemplate template = template("base-order");
         template.header(InternalTokenConstants.HEADER, "caller-token");
+        template.header("Authorization", "Bearer external-token");
+        template.header("x-client-token-user", "{\"username\":\"forged\"}");
 
         interceptor.apply(template);
 
         assertNull(template.headers().get(InternalTokenConstants.HEADER));
+        assertEquals(
+                List.of("Bearer external-token"),
+                List.copyOf(template.headers().get("Authorization")));
+        assertNull(template.headers().get("x-client-token-user"));
+    }
+
+    @Test
+    void shouldRemoveAllManagedCredentialsBeforeSigningAndRemainIdempotent() {
+        InternalTokenProperties properties = properties();
+        FeignInternalTokenInterceptor interceptor = new FeignInternalTokenInterceptor(
+                new DefaultInternalTokenService(new ObjectMapper(), properties),
+                new InternalTokenRequestFactory(new InternalTokenUserContext(new ObjectMapper())),
+                properties,
+                "base-middle");
+        RequestTemplate template = template("base-order");
+        template.header("Authorization", "Bearer external-token");
+        template.header("X-CLIENT-TOKEN", "caller-token");
+        template.header("x-client-token-user", "{\"username\":\"forged\"}");
+
+        interceptor.apply(template);
+        interceptor.apply(template);
+
+        assertNull(template.headers().get("Authorization"));
+        assertNull(template.headers().get("x-client-token-user"));
+        assertEquals(1, template.headers().get(InternalTokenConstants.HEADER).size());
+        assertTrue(interceptor.getOrder() > 0);
+    }
+
+    @Test
+    void shouldRunAfterRegularSpringManagedFeignInterceptors() {
+        InternalTokenProperties properties = properties();
+        FeignInternalTokenInterceptor signer = new FeignInternalTokenInterceptor(
+                new DefaultInternalTokenService(new ObjectMapper(), properties),
+                new InternalTokenRequestFactory(new InternalTokenUserContext(new ObjectMapper())),
+                properties,
+                "base-middle");
+        List<RequestInterceptor> interceptors = new ArrayList<>(List.of(
+                signer, new ManagedCredentialAddingInterceptor()));
+        AnnotationAwareOrderComparator.sort(interceptors);
+        RequestTemplate template = template("base-order");
+
+        interceptors.forEach(interceptor -> interceptor.apply(template));
+
+        assertNull(template.headers().get("Authorization"));
+        assertNull(template.headers().get("x-client-token-user"));
+        assertEquals(1, template.headers().get(InternalTokenConstants.HEADER).size());
     }
 
     private static RequestTemplate template(String targetName) {
@@ -93,5 +146,19 @@ class FeignInternalTokenInterceptorTest {
     }
 
     private interface TestClient {
+    }
+
+    private static final class ManagedCredentialAddingInterceptor
+            implements RequestInterceptor, Ordered {
+        @Override
+        public void apply(RequestTemplate template) {
+            template.header("Authorization", "Bearer external-token");
+            template.header("x-client-token-user", "{\"username\":\"forged\"}");
+        }
+
+        @Override
+        public int getOrder() {
+            return 0;
+        }
     }
 }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/principal/InternalTokenPrincipal.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/principal/InternalTokenPrincipal.java
@@ -9,10 +9,23 @@ public record InternalTokenPrincipal(
         String subject,
         String username,
         List<String> roles,
-        List<String> scopes) {
+        List<String> scopes,
+        List<String> authorities) {
 
     public InternalTokenPrincipal {
         roles = roles == null ? List.of() : List.copyOf(roles);
         scopes = scopes == null ? List.of() : List.copyOf(scopes);
+        authorities = authorities == null ? List.of() : List.copyOf(authorities);
+    }
+
+    /**
+     * Backward-compatible constructor for callers without direct authorities.
+     */
+    public InternalTokenPrincipal(
+            String subject,
+            String username,
+            List<String> roles,
+            List<String> scopes) {
+        this(subject, username, roles, scopes, List.of());
     }
 }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/principal/SpringSecurityInternalTokenPrincipalProvider.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/principal/SpringSecurityInternalTokenPrincipalProvider.java
@@ -50,6 +50,7 @@ public class SpringSecurityInternalTokenPrincipalProvider implements InternalTok
 
             List<String> roles = new ArrayList<>();
             List<String> scopes = new ArrayList<>();
+            List<String> directAuthorities = new ArrayList<>();
             Object authorities = invoke(authentication, "getAuthorities");
             if (authorities instanceof Collection<?> collection) {
                 for (Object authority : collection) {
@@ -59,11 +60,12 @@ public class SpringSecurityInternalTokenPrincipalProvider implements InternalTok
                     } else if (value != null && value.startsWith("SCOPE_") && value.length() > 6) {
                         scopes.add(value.substring(6));
                     } else if (hasText(value)) {
-                        roles.add(value);
+                        directAuthorities.add(value);
                     }
                 }
             }
-            return Optional.of(new InternalTokenPrincipal(subject, username, roles, scopes));
+            return Optional.of(new InternalTokenPrincipal(
+                    subject, username, roles, scopes, directAuthorities));
         } catch (ReflectiveOperationException | RuntimeException exception) {
             return Optional.empty();
         }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
@@ -73,6 +73,7 @@ public class DefaultInternalTokenService implements InternalTokenService {
         payload.put("dst", request.audience());
         payload.put("scope", request.scopes());
         payload.put("roles", request.roles());
+        payload.put("authorities", request.authorities());
         payload.put("hop", request.hop());
         payload.put("parent_jti", request.parentTokenId());
         payload.put("trace_id", request.traceId());
@@ -225,6 +226,7 @@ public class DefaultInternalTokenService implements InternalTokenService {
                 text(claims, "dst"),
                 strings(claims, "scope"),
                 strings(claims, "roles"),
+                strings(claims, "authorities"),
                 number(claims, "hop").intValue(),
                 nullableText(claims, "parent_jti"),
                 nullableText(claims, "trace_id"),

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenClaims.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenClaims.java
@@ -18,6 +18,7 @@ import java.util.Map;
  * @param destination target service
  * @param scopes scope snapshot
  * @param roles role snapshot
+ * @param authorities non-role authority snapshot
  * @param hop current service-call hop
  * @param parentTokenId previous-hop token identifier
  * @param traceId distributed trace identifier
@@ -37,6 +38,7 @@ public record InternalTokenClaims(
         String destination,
         List<String> scopes,
         List<String> roles,
+        List<String> authorities,
         int hop,
         String parentTokenId,
         String traceId,
@@ -46,6 +48,33 @@ public record InternalTokenClaims(
     public InternalTokenClaims {
         scopes = scopes == null ? List.of() : List.copyOf(scopes);
         roles = roles == null ? List.of() : List.copyOf(roles);
+        authorities = authorities == null ? List.of() : List.copyOf(authorities);
         extensions = extensions == null ? Map.of() : Map.copyOf(extensions);
+    }
+
+    /**
+     * Backward-compatible constructor for 0.7.0 claim producers and tests.
+     */
+    public InternalTokenClaims(
+            String issuer,
+            String subject,
+            String username,
+            String audience,
+            String tokenId,
+            long issuedAt,
+            long notBefore,
+            long expiresAt,
+            String source,
+            String destination,
+            List<String> scopes,
+            List<String> roles,
+            int hop,
+            String parentTokenId,
+            String traceId,
+            long keyConfigVersion,
+            Map<String, Object> extensions) {
+        this(issuer, subject, username, audience, tokenId, issuedAt, notBefore, expiresAt,
+                source, destination, scopes, roles, List.of(), hop, parentTokenId, traceId,
+                keyConfigVersion, extensions);
     }
 }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenError.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenError.java
@@ -5,6 +5,7 @@ package io.github.opensabre.security.token;
  */
 public enum InternalTokenError {
     MISSING_TOKEN,
+    AMBIGUOUS_CREDENTIALS,
     MALFORMED_TOKEN,
     UNSUPPORTED_ALGORITHM,
     UNKNOWN_KEY,

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenRequest.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenRequest.java
@@ -13,6 +13,7 @@ public record InternalTokenRequest(
         String audience,
         List<String> scopes,
         List<String> roles,
+        List<String> authorities,
         int hop,
         String parentTokenId,
         String traceId,
@@ -21,6 +22,25 @@ public record InternalTokenRequest(
     public InternalTokenRequest {
         scopes = scopes == null ? List.of() : List.copyOf(scopes);
         roles = roles == null ? List.of() : List.copyOf(roles);
+        authorities = authorities == null ? List.of() : List.copyOf(authorities);
         extensions = extensions == null ? Map.of() : Map.copyOf(extensions);
+    }
+
+    /**
+     * Backward-compatible constructor for callers compiled against Framework 0.7.0.
+     */
+    public InternalTokenRequest(
+            String issuer,
+            String subject,
+            String username,
+            String audience,
+            List<String> scopes,
+            List<String> roles,
+            int hop,
+            String parentTokenId,
+            String traceId,
+            Map<String, Object> extensions) {
+        this(issuer, subject, username, audience, scopes, roles, List.of(),
+                hop, parentTokenId, traceId, extensions);
     }
 }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenRequestFactory.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/InternalTokenRequestFactory.java
@@ -54,6 +54,9 @@ public class InternalTokenRequestFactory {
         List<String> roles = current != null
                 ? new ArrayList<>(holder.getRoles())
                 : principal == null ? List.of() : principal.roles();
+        List<String> authorities = current != null
+                ? current.authorities()
+                : principal == null ? List.of() : principal.authorities();
         int hop = current == null ? 1 : current.hop() + 1;
         String parentTokenId = current == null ? null : current.tokenId();
         Map<String, Object> extensions = current == null ? Map.of() : current.extensions();
@@ -65,6 +68,7 @@ public class InternalTokenRequestFactory {
                 audience,
                 scopes,
                 roles,
+                authorities,
                 hop,
                 parentTokenId,
                 holder.getValue("trace_id"),

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/webmvc/InternalTokenAuthenticationFilter.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/webmvc/InternalTokenAuthenticationFilter.java
@@ -4,6 +4,7 @@ import io.github.opensabre.security.config.InternalTokenProperties;
 import io.github.opensabre.security.context.InternalTokenUserContext;
 import io.github.opensabre.security.token.InternalTokenClaims;
 import io.github.opensabre.security.token.InternalTokenConstants;
+import io.github.opensabre.security.token.InternalTokenError;
 import io.github.opensabre.security.token.InternalTokenException;
 import io.github.opensabre.security.token.InternalTokenService;
 import jakarta.servlet.FilterChain;
@@ -71,7 +72,7 @@ public class InternalTokenAuthenticationFilter extends OncePerRequestFilter {
         if (hasBearerToken(request)) {
             response.sendError(
                     HttpServletResponse.SC_UNAUTHORIZED,
-                    "external and internal tokens cannot be used together");
+                    InternalTokenError.AMBIGUOUS_CREDENTIALS.name());
             return;
         }
         if (!StringUtils.hasText(applicationName)) {
@@ -115,12 +116,24 @@ public class InternalTokenAuthenticationFilter extends OncePerRequestFilter {
         Set<GrantedAuthority> authorities = new LinkedHashSet<>();
         claims.roles().stream()
                 .filter(StringUtils::hasText)
-                .map(SimpleGrantedAuthority::new)
+                .map(InternalTokenAuthenticationFilter::roleAuthority)
                 .forEach(authorities::add);
         claims.scopes().stream()
                 .filter(StringUtils::hasText)
                 .map(scope -> new SimpleGrantedAuthority("SCOPE_" + scope))
                 .forEach(authorities::add);
+        claims.authorities().stream()
+                .filter(StringUtils::hasText)
+                .map(SimpleGrantedAuthority::new)
+                .forEach(authorities::add);
         return authorities;
+    }
+
+    /**
+     * Restores Spring Security role semantics while accepting 0.7.0 tokens
+     * that encoded role names without the {@code ROLE_} prefix.
+     */
+    private static SimpleGrantedAuthority roleAuthority(String role) {
+        return new SimpleGrantedAuthority(role.startsWith("ROLE_") ? role : "ROLE_" + role);
     }
 }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/webmvc/InternalTokenMvcInterceptor.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/webmvc/InternalTokenMvcInterceptor.java
@@ -3,6 +3,7 @@ package io.github.opensabre.security.webmvc;
 import io.github.opensabre.security.config.InternalTokenProperties;
 import io.github.opensabre.security.context.InternalTokenUserContext;
 import io.github.opensabre.security.token.InternalTokenConstants;
+import io.github.opensabre.security.token.InternalTokenError;
 import io.github.opensabre.security.token.InternalTokenException;
 import io.github.opensabre.security.token.InternalTokenService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -54,6 +55,12 @@ public class InternalTokenMvcInterceptor implements HandlerInterceptor {
             }
             return true;
         }
+        if (hasBearerToken(request)) {
+            response.sendError(
+                    HttpServletResponse.SC_UNAUTHORIZED,
+                    InternalTokenError.AMBIGUOUS_CREDENTIALS.name());
+            return false;
+        }
         if (!StringUtils.hasText(applicationName)) {
             response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "spring.application.name is required");
             return false;
@@ -66,6 +73,12 @@ public class InternalTokenMvcInterceptor implements HandlerInterceptor {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED, exception.getError().name());
             return false;
         }
+    }
+
+    private static boolean hasBearerToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        return StringUtils.hasText(authorization)
+                && authorization.regionMatches(true, 0, "Bearer ", 0, 7);
     }
 
     private boolean isExcluded(String requestUri) {

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/principal/SpringSecurityInternalTokenPrincipalProviderTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/principal/SpringSecurityInternalTokenPrincipalProviderTest.java
@@ -21,7 +21,7 @@ class SpringSecurityInternalTokenPrincipalProviderTest {
     }
 
     @Test
-    void preservesDirectRoleAuthoritiesAndSeparatesScopes() {
+    void separatesRolesScopesAndDirectAuthorities() {
         SecurityContextHolder.getContext().setAuthentication(
                 new UsernamePasswordAuthenticationToken(
                         "operator",
@@ -34,7 +34,8 @@ class SpringSecurityInternalTokenPrincipalProviderTest {
         InternalTokenPrincipal principal = provider.currentPrincipal().orElseThrow();
 
         assertEquals("operator", principal.subject());
-        assertEquals(List.of("ADMIN", "AUDITOR"), principal.roles());
+        assertEquals(List.of("AUDITOR"), principal.roles());
         assertEquals(List.of("keys.read"), principal.scopes());
+        assertEquals(List.of("ADMIN"), principal.authorities());
     }
 }

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/token/DefaultInternalTokenServiceTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/token/DefaultInternalTokenServiceTest.java
@@ -35,6 +35,7 @@ class DefaultInternalTokenServiceTest {
         assertEquals("zhangsan", claims.username());
         assertEquals(List.of("order:read"), claims.scopes());
         assertEquals(List.of("admin"), claims.roles());
+        assertEquals(List.of("ORDER_WRITE"), claims.authorities());
         assertEquals("tenant-a", claims.extensions().get("tenant"));
         assertEquals(42, claims.keyConfigVersion());
     }
@@ -140,6 +141,7 @@ class DefaultInternalTokenServiceTest {
                 audience,
                 List.of("order:read"),
                 List.of("admin"),
+                List.of("ORDER_WRITE"),
                 1,
                 "parent-token",
                 "trace-1",

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/token/InternalTokenRequestFactoryTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/token/InternalTokenRequestFactoryTest.java
@@ -27,7 +27,8 @@ class InternalTokenRequestFactoryTest {
         InternalTokenRequestFactory factory = new InternalTokenRequestFactory(
                 context,
                 () -> Optional.of(new InternalTokenPrincipal(
-                        "user-1", "zhangsan", List.of("admin"), List.of("order:read"))));
+                        "user-1", "zhangsan", List.of("admin"), List.of("order:read"),
+                        List.of("ORDER_WRITE"))));
 
         InternalTokenRequest request = factory.create("base-organization", "base-order");
 
@@ -35,6 +36,7 @@ class InternalTokenRequestFactoryTest {
         assertEquals("zhangsan", request.username());
         assertEquals(List.of("admin"), request.roles());
         assertEquals(List.of("order:read"), request.scopes());
+        assertEquals(List.of("ORDER_WRITE"), request.authorities());
         assertEquals(1, request.hop());
         assertNull(request.parentTokenId());
     }

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/webmvc/InternalTokenAuthenticationFilterTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/webmvc/InternalTokenAuthenticationFilterTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockFilterChain;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authorization.AuthorityAuthorizationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 
@@ -51,7 +52,16 @@ class InternalTokenAuthenticationFilterTest {
         assertThat(observed.get().getName()).isEqualTo("admin");
         assertThat(observed.get().getAuthorities())
                 .extracting("authority")
-                .containsExactlyInAnyOrder("ADMIN", "SCOPE_internal-token:read");
+                .containsExactlyInAnyOrder("ROLE_ADMIN", "SCOPE_internal-token:read", "ORDER_WRITE");
+        assertThat(AuthorityAuthorizationManager.hasRole("ADMIN")
+                .check(() -> observed.get(), null)
+                .isGranted()).isTrue();
+        assertThat(AuthorityAuthorizationManager.hasAuthority("SCOPE_internal-token:read")
+                .check(() -> observed.get(), null)
+                .isGranted()).isTrue();
+        assertThat(AuthorityAuthorizationManager.hasAuthority("ORDER_WRITE")
+                .check(() -> observed.get(), null)
+                .isGranted()).isTrue();
         assertThat(UserContextHolder.getInstance().getContext()).isEmpty();
         assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
     }
@@ -84,6 +94,7 @@ class InternalTokenAuthenticationFilterTest {
         filter.doFilter(request, response, new MockFilterChain());
 
         assertThat(response.getStatus()).isEqualTo(401);
+        assertThat(response.getErrorMessage()).isEqualTo("AMBIGUOUS_CREDENTIALS");
     }
 
     @Test
@@ -138,7 +149,8 @@ class InternalTokenAuthenticationFilterTest {
         return new InternalTokenClaims(
                 "base-order", "user-1", "admin", "base-sysadmin", "jti-1",
                 1, 1, 60, "base-order", "base-sysadmin",
-                List.of("internal-token:read"), List.of("ADMIN"), 1, null, "trace-1", 3,
+                List.of("internal-token:read"), List.of("ADMIN"), List.of("ORDER_WRITE"),
+                1, null, "trace-1", 3,
                 Map.of("tenant", "default"));
     }
 }

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/webmvc/InternalTokenMvcInterceptorTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/webmvc/InternalTokenMvcInterceptorTest.java
@@ -63,6 +63,22 @@ class InternalTokenMvcInterceptorTest {
     }
 
     @Test
+    void shouldRejectAmbiguousExternalAndInternalCredentials() throws Exception {
+        InternalTokenProperties properties = properties();
+        InternalTokenService service = new DefaultInternalTokenService(new ObjectMapper(), properties);
+        InternalTokenMvcInterceptor interceptor = new InternalTokenMvcInterceptor(
+                service, new InternalTokenUserContext(new ObjectMapper()), properties, "base-order");
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("x-client-token", service.issue(request()));
+        request.addHeader("Authorization", "Bearer external-jwt");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertEquals(false, interceptor.preHandle(request, response, new Object()));
+        assertEquals(401, response.getStatus());
+        assertEquals("AMBIGUOUS_CREDENTIALS", response.getErrorMessage());
+    }
+
+    @Test
     void shouldAllowExternalJwtRequestWhenTokenIsNotRequired() throws Exception {
         InternalTokenProperties properties = properties();
         InternalTokenMvcInterceptor interceptor = new InternalTokenMvcInterceptor(

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>0.7.0</revision>
+        <revision>0.7.1</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
## 变更\n- 修复 Feign 内部 Token 重签前的受管凭证清理与执行顺序\n- 恢复 Spring Security ROLE_ 语义，并独立传递 scopes/roles/authorities\n- MVC 与 Security Filter 统一拒绝双凭证，返回 AMBIGUOUS_CREDENTIALS\n- 为错误码与字典注册增加受管调度、有限重试、退避、指标、Actuator 状态与手动触发\n- 升级 revision 到 0.7.1，补充滚动升级和运维文档\n\n## 兼容性\n- 保留 0.7.0 的 InternalTokenRequest、InternalTokenClaims、InternalTokenPrincipal 构造器\n- 0.7.1 可读取不含 authorities 的旧 Token\n- 直接 Authority 在混合版本链路中要求所有重签中间服务升级到 0.7.1\n\n## 验证\n- mvn test\n- 独立代码审查：APPROVE\n- 架构审查：WATCH（混合版本 Authority 已记录升级说明，无发布阻断）\n\nCloses #36\nCloses #37\nCloses #38\nCloses #39