### PR TITLE
fix: 修复 0.7.1 发布测试构造器

### DIFF
--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListenerTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/errorcatalog/ErrorCatalogRegistrationListenerTest.java
@@ -1,9 +1,14 @@
 package io.github.opensabre.governance.errorcatalog;
 
 import io.github.opensabre.governance.client.SysadminGovernanceClient;
+import io.github.opensabre.governance.config.GovernanceProperties;
+import io.github.opensabre.governance.registration.GovernanceRegistrationCoordinator;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.mock.env.MockEnvironment;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import java.lang.reflect.Proxy;
 import java.util.List;
@@ -14,6 +19,15 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ErrorCatalogRegistrationListenerTest {
+
+    private ThreadPoolTaskScheduler scheduler;
+
+    @AfterEach
+    void shutdownScheduler() {
+        if (scheduler != null) {
+            scheduler.shutdown();
+        }
+    }
 
     @Test
     void registersResolvedSnapshotAfterApplicationIsReady() throws InterruptedException {
@@ -54,7 +68,22 @@ class ErrorCatalogRegistrationListenerTest {
                 .withProperty("spring.application.name", "base-demo")
                 .withProperty("opensabre.governance.error-catalog.registration-token",
                         "registration-secret");
-        return new ErrorCatalogRegistrationListener(clientProvider, List.of(provider), environment);
+        scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(1);
+        scheduler.setThreadNamePrefix("error-catalog-registration-test-");
+        scheduler.initialize();
+        ObjectProvider<MeterRegistry> meterRegistryProvider = new ObjectProvider<>() {
+            @Override
+            public MeterRegistry getObject() {
+                return null;
+            }
+        };
+        GovernanceProperties properties = new GovernanceProperties();
+        properties.getRegistration().setMaxAttempts(1);
+        GovernanceRegistrationCoordinator coordinator = new GovernanceRegistrationCoordinator(
+                scheduler, properties, meterRegistryProvider);
+        return new ErrorCatalogRegistrationListener(
+                clientProvider, List.of(provider), environment, coordinator);
     }
 
     private SysadminGovernanceClient client(RegistrationCall registrationCall) {


### PR DESCRIPTION
## 修复
- 为错误码注册监听器测试注入治理注册协调器
- 使用真实测试调度器并在测试后关闭
- 单次尝试避免 teardown 期间安排重试

## 根因
PR #44 合并时，main 上并发加入的测试仍调用旧三参数构造器，导致 Maven Central 发布在 testCompile 阶段失败。

## 验证
- mvn -B -pl opensabre-starter-governance -Dtest=ErrorCatalogRegistrationListenerTest test
- mvn -B clean test
- git diff --check