### PR TITLE
fix: 统一篡改内部 Token 的签名错误

### DIFF
--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
@@ -119,23 +119,24 @@ public class DefaultInternalTokenService implements InternalTokenService {
                 throw new InternalTokenException(InternalTokenError.UNKNOWN_KEY, "unknown internal token key id");
             }
             byte[] expectedSignature = sign(parts[0] + "." + parts[1], key);
+            
             byte[] actualSignature;
             try {
                 actualSignature = BASE64_URL_DECODER.decode(parts[2]);
             } catch (IllegalArgumentException exception) {
                 throw new InternalTokenException(InternalTokenError.INVALID_SIGNATURE, "internal token signature encoding is invalid", exception);
             }
+            
             if (!MessageDigest.isEqual(expectedSignature, actualSignature)) {
                 throw new InternalTokenException(InternalTokenError.INVALID_SIGNATURE, "internal token signature is invalid");
             }
+            
             InternalTokenClaims claims = toClaims(decodeMap(parts[1]));
             validateClaims(claims, expectedAudience);
             validateExtensions(claims.extensions());
             return claims;
         } catch (InternalTokenException exception) {
             throw exception;
-        } catch (IllegalArgumentException exception) {
-            throw new InternalTokenException(InternalTokenError.MALFORMED_TOKEN, "internal token encoding is invalid", exception);
         } catch (Exception exception) {
             throw new InternalTokenException(InternalTokenError.MALFORMED_TOKEN, "cannot parse internal token", exception);
         }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
@@ -119,7 +119,12 @@ public class DefaultInternalTokenService implements InternalTokenService {
                 throw new InternalTokenException(InternalTokenError.UNKNOWN_KEY, "unknown internal token key id");
             }
             byte[] expectedSignature = sign(parts[0] + "." + parts[1], key);
-            byte[] actualSignature = BASE64_URL_DECODER.decode(parts[2]);
+            byte[] actualSignature;
+            try {
+                actualSignature = BASE64_URL_DECODER.decode(parts[2]);
+            } catch (IllegalArgumentException exception) {
+                throw new InternalTokenException(InternalTokenError.INVALID_SIGNATURE, "internal token signature encoding is invalid", exception);
+            }
             if (!MessageDigest.isEqual(expectedSignature, actualSignature)) {
                 throw new InternalTokenException(InternalTokenError.INVALID_SIGNATURE, "internal token signature is invalid");
             }


### PR DESCRIPTION
将篡改签名触发的 Base64 解码异常映射为 INVALID_SIGNATURE，避免暴露底层 IllegalArgumentException。\n\n本地验证：opensabre-starter-security 的 DefaultInternalTokenServiceTest 已通过。