### PR TITLE
ci: 升级 GitHub Actions 至 JDK 21

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,10 +11,10 @@ jobs:
       # 1. 声明 checkout 仓库代码到工作区
     - uses: actions/checkout@v4
       # 2. 安装Java 环境 这里会用到的参数就是 Git Action secrets中配置的，
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: '21'
         distribution: temurin
         cache: maven
       # 3.编译打包


### PR DESCRIPTION
将 GitHub Actions 运行时升级为 Temurin JDK 21。Maven source/target 仍保持 Java 17，因此产物兼容性不变。\n\n验证：已完成工作流 YAML 与 git diff --check 校验。