### PR TITLE
chore: 发布 Framework 0.7.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Maven Central Repo
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: '21'
           distribution: temurin
           cache: maven
           server-id: sonatype-nexus-staging

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>0.7.1</revision>
+        <revision>0.7.2</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
## 变更

- 修复篡改内部 Token 签名的错误分类。
- GitHub Actions 与 Maven Central 发布工作流升级至 Temurin JDK 21。
- Maven 产物仍保持 Java 17 编译目标。

## 验证

- 本地 mvn package javadoc:javadoc 全量 15 模块通过。