### PR TITLE
feat: 增加 Nacos 公共配置入口

### DIFF
--- a/opensabre-starter-config/src/main/java/io/github/opensabre/config/OpensabreConfig.java
+++ b/opensabre-starter-config/src/main/java/io/github/opensabre/config/OpensabreConfig.java
@@ -4,6 +4,9 @@ import io.github.opensabre.boot.config.YamlPropertyLoaderFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.context.annotation.PropertySource;
 
+/**
+ * 加载 OpenSabre Nacos 配置中心的共享配置定位规则。
+ */
 @AutoConfiguration
 @PropertySource(value = {"classpath:opensabre-config.yml"}, encoding = "UTF8", factory = YamlPropertyLoaderFactory.class)
 public class OpensabreConfig {

--- a/opensabre-starter-config/src/main/resources/opensabre-config.yml
+++ b/opensabre-starter-config/src/main/resources/opensabre-config.yml
@@ -5,6 +5,11 @@ spring:
         server-addr: ${REGISTER_HOST:localhost}:${REGISTER_PORT:8848}
         file-extension: yml
         shared-configs:
+          # 跨服务、非敏感的运行配置，例如资源服务 JWK 地址。
+          - data-id: ${OPENSABRE_COMMON_CONFIG_DATA_ID:opensabre-common.yml}
+            group: ${OPENSABRE_COMMON_CONFIG_GROUP:DEFAULT_GROUP}
+            refresh: true
+          # 安全策略配置与通用运行配置分离，密钥本身不得写入 Nacos 公共配置。
           - data-id: ${OPENSABRE_SECURITY_CONFIG_DATA_ID:opensabre-security.yml}
             group: ${OPENSABRE_SECURITY_CONFIG_GROUP:DEFAULT_GROUP}
             refresh: true

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/token/DefaultInternalTokenServiceTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/token/DefaultInternalTokenServiceTest.java
@@ -95,8 +95,12 @@ class DefaultInternalTokenServiceTest {
         DefaultInternalTokenService service = service(
                 properties("active", "0123456789abcdef0123456789abcdef"), NOW);
         String token = service.issue(request("base-order", Map.of()));
-        String tampered = token.substring(0, token.length() - 1)
-                + (token.endsWith("a") ? "b" : "a");
+        int signatureStart = token.lastIndexOf('.') + 1;
+        char firstSignatureCharacter = token.charAt(signatureStart);
+        // 修改有效 Base64URL 位，避免只修改末尾未参与解码的填充位。
+        String tampered = token.substring(0, signatureStart)
+                + (firstSignatureCharacter == 'A' ? 'B' : 'A')
+                + token.substring(signatureStart + 1);
 
         InternalTokenException exception = assertThrows(
                 InternalTokenException.class, () -> service.verify(tampered, "base-order"));

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>0.7.2</revision>
+        <revision>0.7.3</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
包含 opensabre-common.yml 共享配置入口，以及内部令牌篡改签名回归测试修复。CI: https://github.com/opensabre/opensabre-framework/actions/runs/30692451989