### PR TITLE
fix: 在 Bootstrap 阶段加载 Nacos 公共配置

### DIFF
--- a/opensabre-starter-config/pom.xml
+++ b/opensabre-starter-config/pom.xml
@@ -43,5 +43,10 @@
             <groupId>io.github.opensabre</groupId>
             <artifactId>opensabre-starter-boot</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/opensabre-starter-config/src/main/java/io/github/opensabre/config/bootstrap/OpensabreCommonNacosPropertySourceLocator.java
+++ b/opensabre-starter-config/src/main/java/io/github/opensabre/config/bootstrap/OpensabreCommonNacosPropertySourceLocator.java
@@ -1,0 +1,69 @@
+package io.github.opensabre.config.bootstrap;
+
+import com.alibaba.nacos.api.NacosFactory;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.core.env.CompositePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+/**
+ * 在 Spring Cloud Bootstrap 阶段加载 OpenSabre 的 Nacos 公共配置。
+ *
+ * <p>不能使用普通 AutoConfiguration 的 {@code @PropertySource} 声明共享配置；
+ * 该阶段晚于 Nacos Bootstrap，导致 Data ID 不会被订阅。</p>
+ */
+public class OpensabreCommonNacosPropertySourceLocator implements PropertySourceLocator {
+
+    private static final String CONFIG_NAME = "opensabreCommonNacos";
+    private static final Logger log = LoggerFactory.getLogger(OpensabreCommonNacosPropertySourceLocator.class);
+    private final NacosCommonConfigLoader configLoader;
+
+    public OpensabreCommonNacosPropertySourceLocator() {
+        this((properties, dataId, group, timeout) ->
+                NacosFactory.createConfigService(properties).getConfig(dataId, group, timeout));
+    }
+
+    OpensabreCommonNacosPropertySourceLocator(NacosCommonConfigLoader configLoader) {
+        this.configLoader = configLoader;
+    }
+
+    @Override
+    public PropertySource<?> locate(Environment environment) {
+        String dataId = environment.getProperty("OPENSABRE_COMMON_CONFIG_DATA_ID", "opensabre-common.yml");
+        String group = environment.getProperty("OPENSABRE_COMMON_CONFIG_GROUP", "DEFAULT_GROUP");
+        String serverAddr = environment.getProperty("spring.cloud.nacos.config.server-addr",
+                environment.getProperty("REGISTER_HOST", "localhost") + ":"
+                        + environment.getProperty("REGISTER_PORT", "8848"));
+        try {
+            Properties properties = new Properties();
+            properties.setProperty("serverAddr", serverAddr);
+            String content = configLoader.load(properties, dataId, group, 3000);
+            if (!StringUtils.hasText(content)) {
+                return null;
+            }
+            CompositePropertySource source = new CompositePropertySource(CONFIG_NAME);
+            for (PropertySource<?> propertySource : new YamlPropertySourceLoader().load(CONFIG_NAME,
+                    new ByteArrayResource(content.getBytes(StandardCharsets.UTF_8)))) {
+                source.addFirstPropertySource(propertySource);
+            }
+            log.info("Loaded OpenSabre Nacos common config {}/{} during Bootstrap", group, dataId);
+            return source;
+        }
+        catch (Exception ex) {
+            throw new IllegalStateException("Failed to load Nacos common config " + group + "/" + dataId, ex);
+        }
+    }
+
+    @FunctionalInterface
+    interface NacosCommonConfigLoader {
+        String load(Properties properties, String dataId, String group, long timeout) throws Exception;
+    }
+}

--- a/opensabre-starter-config/src/main/java/io/github/opensabre/config/bootstrap/OpensabreNacosBootstrapConfiguration.java
+++ b/opensabre-starter-config/src/main/java/io/github/opensabre/config/bootstrap/OpensabreNacosBootstrapConfiguration.java
@@ -1,0 +1,18 @@
+package io.github.opensabre.config.bootstrap;
+
+import org.springframework.cloud.bootstrap.config.PropertySourceLocator;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+/** Registers OpenSabre common configuration before Nacos application configuration. */
+@Configuration(proxyBeanMethods = false)
+public class OpensabreNacosBootstrapConfiguration {
+
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    PropertySourceLocator opensabreCommonNacosPropertySourceLocator() {
+        return new OpensabreCommonNacosPropertySourceLocator();
+    }
+}

--- a/opensabre-starter-config/src/main/resources/META-INF/spring.factories
+++ b/opensabre-starter-config/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.cloud.bootstrap.BootstrapConfiguration=\
+io.github.opensabre.config.bootstrap.OpensabreNacosBootstrapConfiguration

--- a/opensabre-starter-config/src/main/resources/opensabre-config.yml
+++ b/opensabre-starter-config/src/main/resources/opensabre-config.yml
@@ -4,12 +4,5 @@ spring:
       config:
         server-addr: ${REGISTER_HOST:localhost}:${REGISTER_PORT:8848}
         file-extension: yml
-        shared-configs:
-          # 跨服务、非敏感的运行配置，例如资源服务 JWK 地址。
-          - data-id: ${OPENSABRE_COMMON_CONFIG_DATA_ID:opensabre-common.yml}
-            group: ${OPENSABRE_COMMON_CONFIG_GROUP:DEFAULT_GROUP}
-            refresh: true
-          # 安全策略配置与通用运行配置分离，密钥本身不得写入 Nacos 公共配置。
-          - data-id: ${OPENSABRE_SECURITY_CONFIG_DATA_ID:opensabre-security.yml}
-            group: ${OPENSABRE_SECURITY_CONFIG_GROUP:DEFAULT_GROUP}
-            refresh: true
+        # Nacos 连接属性由应用 bootstrap.yml 或部署环境提供。
+        # 公共配置由 META-INF/spring.factories 中的 BootstrapConfiguration 提前加载。

--- a/opensabre-starter-config/src/test/java/io/github/opensabre/config/bootstrap/OpensabreCommonNacosPropertySourceLocatorTest.java
+++ b/opensabre-starter-config/src/test/java/io/github/opensabre/config/bootstrap/OpensabreCommonNacosPropertySourceLocatorTest.java
@@ -1,0 +1,30 @@
+package io.github.opensabre.config.bootstrap;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.PropertySource;
+import org.springframework.mock.env.MockEnvironment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpensabreCommonNacosPropertySourceLocatorTest {
+
+    @Test
+    void shouldLoadCommonYamlDuringBootstrap() {
+        OpensabreCommonNacosPropertySourceLocator locator =
+                new OpensabreCommonNacosPropertySourceLocator((properties, dataId, group, timeout) -> {
+                    assertThat(properties.getProperty("serverAddr")).isEqualTo("rnacos:8848");
+                    assertThat(dataId).isEqualTo("opensabre-common.yml");
+                    assertThat(group).isEqualTo("DEFAULT_GROUP");
+                    assertThat(timeout).isEqualTo(3000);
+                    return "spring:\n  security:\n    oauth2:\n      resourceserver:\n        jwt:\n          jwk-set-uri: http://base-authorization:8000/oauth2/jwks\n";
+                });
+
+        PropertySource<?> source = locator.locate(new MockEnvironment()
+                .withProperty("REGISTER_HOST", "rnacos")
+                .withProperty("REGISTER_PORT", "8848"));
+
+        assertThat(source).isNotNull();
+        assertThat(source.getProperty("spring.security.oauth2.resourceserver.jwt.jwk-set-uri"))
+                .isEqualTo("http://base-authorization:8000/oauth2/jwks");
+    }
+}

--- a/opensabre-starter-config/src/test/java/io/github/opensabre/config/bootstrap/OpensabreNacosBootstrapRegistrationTest.java
+++ b/opensabre-starter-config/src/test/java/io/github/opensabre/config/bootstrap/OpensabreNacosBootstrapRegistrationTest.java
@@ -1,0 +1,28 @@
+package io.github.opensabre.config.bootstrap;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpensabreNacosBootstrapRegistrationTest {
+
+    @Test
+    void shouldRegisterBootstrapConfigurationInSpringFactories() throws Exception {
+        Enumeration<URL> resources = getClass().getClassLoader().getResources("META-INF/spring.factories");
+        boolean registered = false;
+        while (resources.hasMoreElements()) {
+            try (InputStream input = resources.nextElement().openStream()) {
+                Properties properties = new Properties();
+                properties.load(input);
+                String configurations = properties.getProperty("org.springframework.cloud.bootstrap.BootstrapConfiguration", "");
+                registered |= configurations.contains(OpensabreNacosBootstrapConfiguration.class.getName());
+            }
+        }
+        assertThat(registered).isTrue();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>0.7.3</revision>
+        <revision>0.7.4</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
修复 0.7.3 中 @PropertySource 晚于 Nacos Bootstrap、导致 opensabre-common.yml 未加载的问题。\n\n验证：\n- 框架 0.7.4 本地完整 install\n- Bootstrap 注册与 YAML/JWK 属性回归测试通过\n- base-authorization 本地升级到 0.7.4 后构建成功\n- 本地启动日志确认 DEFAULT_GROUP/opensabre-common.yml 在 Bootstrap 阶段加载