### PR TITLE
feat: 统一治理能力注册凭据

### DIFF
--- a/docs/modules/dictionary.md
+++ b/docs/modules/dictionary.md
@@ -9,13 +9,15 @@ opensabre:
   governance:
     dictionary:
       enabled: true
-      registration-enabled: false
-      registration-token: ${DICTIONARY_REGISTRATION_TOKEN:${ERROR_CATALOG_REGISTRATION_TOKEN:}}
+      registration-enabled: true
+      registration-token: ${DICTIONARY_REGISTRATION_TOKEN:${GOVERNANCE_REGISTRATION_TOKEN:${ERROR_CATALOG_REGISTRATION_TOKEN:}}}
       preload-codes: [order_status]
 ```
 
-`registration-enabled` 默认关闭。只有后端实现字典快照注册协议后才可开启。
-0.7.1 起注册任务使用[治理注册运行时](governance-registration.md)执行有限重试并暴露运行状态。
+`registration-enabled` 默认开启；没有声明 `DictionaryProvider` 的应用不会发起注册请求。
+字典与错误码上报默认共享 `GOVERNANCE_REGISTRATION_TOKEN`，也可通过
+`DICTIONARY_REGISTRATION_TOKEN` 单独覆盖。`ERROR_CATALOG_REGISTRATION_TOKEN` 仅作为旧部署兼容回退。
+注册任务使用[治理注册运行时](governance-registration.md)执行有限重试并暴露运行状态。
 
 ## 声明与读取
 
@@ -51,6 +53,5 @@ Framework 客户端约定：
 | `POST` | `/dicts/snapshots` | 携带 `X-Opensabre-Dictionary-Token` 注册应用字典快照 |
 | `GET` | `/dicts/{dictCode}/items/all` | 返回包含停用项的完整字典项列表 |
 
-`base-sysadmin` 0.7.1 已实现以上两个治理协议端点，并校验字典归属与注册凭据。
-Framework 与 Sysadmin 应同时升级到 0.7.1 后再开启 `registration-enabled`；
-混用旧版 Sysadmin 时保持为 `false`。
+`base-sysadmin` 已实现以上治理协议。应用启动注册采用尽力而为语义：注册失败会记录日志，
+但不会阻止应用启动；读取失败仍抛出 `DictionaryUnavailableException`，由业务决定降级策略。

--- a/docs/modules/error-catalog.md
+++ b/docs/modules/error-catalog.md
@@ -13,7 +13,9 @@ ErrorCatalogProvider orderErrorCatalogProvider() {
 }
 ```
 
-所有参与上报的应用与 `base-sysadmin` 必须配置相同的 `ERROR_CATALOG_REGISTRATION_TOKEN`。目录端拒绝空凭据、无效凭据和被其他应用占用的错误码。
+所有参与上报的应用与 `base-sysadmin` 默认共享 `GOVERNANCE_REGISTRATION_TOKEN`。
+如需为错误码能力单独设置凭据，可用 `ERROR_CATALOG_REGISTRATION_TOKEN` 覆盖公共凭据。
+目录端拒绝空凭据、无效凭据和被其他应用占用的错误码。
 
 Framework 在发送快照前会补齐定义归属：业务 Provider 的错误码归当前应用所有，
 范围为 `APPLICATION`；内置 `SystemErrorType` 归 `opensabre-framework` 所有，

--- a/opensabre-starter-governance/src/main/resources/opensabre-governance.yml
+++ b/opensabre-starter-governance/src/main/resources/opensabre-governance.yml
@@ -25,9 +25,9 @@ opensabre:
       fail-open: true
     error-catalog:
       enabled: true
-      registration-token: ${ERROR_CATALOG_REGISTRATION_TOKEN:}
+      registration-token: ${ERROR_CATALOG_REGISTRATION_TOKEN:${GOVERNANCE_REGISTRATION_TOKEN:}}
     dictionary:
       enabled: true
-      registration-enabled: false
-      registration-token: ${DICTIONARY_REGISTRATION_TOKEN:${ERROR_CATALOG_REGISTRATION_TOKEN:}}
+      registration-enabled: true
+      registration-token: ${DICTIONARY_REGISTRATION_TOKEN:${GOVERNANCE_REGISTRATION_TOKEN:${ERROR_CATALOG_REGISTRATION_TOKEN:}}}
       preload-codes: []

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/config/GovernanceDefaultPropertiesTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/config/GovernanceDefaultPropertiesTest.java
@@ -1,0 +1,33 @@
+package io.github.opensabre.governance.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** 验证治理 Starter 的公共上报凭据与字典注册默认配置。 */
+class GovernanceDefaultPropertiesTest {
+
+    @Test
+    void sharesGovernanceTokenAndEnablesDictionaryRegistration() throws IOException {
+        StandardEnvironment environment = new StandardEnvironment();
+        environment.getPropertySources().addFirst(new MapPropertySource(
+                "governance-token", Map.of("GOVERNANCE_REGISTRATION_TOKEN", "shared-token")));
+        new YamlPropertySourceLoader().load(
+                        "opensabre-governance", new ClassPathResource("opensabre-governance.yml"))
+                .forEach(environment.getPropertySources()::addLast);
+
+        assertEquals("shared-token", environment.getProperty(
+                "opensabre.governance.error-catalog.registration-token"));
+        assertEquals("shared-token", environment.getProperty(
+                "opensabre.governance.dictionary.registration-token"));
+        assertEquals(Boolean.TRUE, environment.getProperty(
+                "opensabre.governance.dictionary.registration-enabled", Boolean.class));
+    }
+}


### PR DESCRIPTION
## 变更
- 错误码与字典注册默认共享 GOVERNANCE_REGISTRATION_TOKEN
- 字典注册默认开启，无 Provider 时不发起请求
- 增加默认配置测试并更新文档

## 验证
- mvn -Drevision=0.7.5-SNAPSHOT clean install
- 15 个 Reactor 模块全部成功