### PR TITLE
feat: 增加字典枚举自动注册与字典值校验

### DIFF
--- a/docs/modules/dictionary.md
+++ b/docs/modules/dictionary.md
@@ -1,6 +1,6 @@
 # 字典治理组件
 
-`opensabre-starter-governance` 0.7.0 提供应用侧字典声明、启动注册、预热和本地缓存读取能力。
+`opensabre-starter-governance` 0.7.6-SNAPSHOT 提供应用侧字典声明、启动注册、预热和本地缓存读取能力。
 
 ## 配置
 
@@ -21,6 +21,48 @@ opensabre:
 
 ## 声明与读取
 
+### 标准枚举自动注册
+
+推荐使用 `DictionaryEnum` + `@OpenSabreDictionary` 声明固定枚举字典：
+
+```java
+@OpenSabreDictionary(code = "gender", name = "用户性别")
+public enum Gender implements DictionaryEnum {
+    FEMALE("F", "女"),
+    MALE("M", "男");
+
+    private final String value;
+    private final String label;
+
+    Gender(String value, String label) {
+        this.value = value;
+        this.label = label;
+    }
+
+    @Override public String value() { return value; }
+    @Override public String label() { return label; }
+}
+```
+
+治理 Starter 默认扫描 Spring Boot 应用的自动配置包。也可以显式指定：
+
+```yaml
+opensabre:
+  governance:
+    dictionary:
+      scan-packages:
+        - com.example.user.enums
+```
+
+只有同时满足以下条件的类型才会自动上报：
+
+- 是 `enum`；
+- 实现 `DictionaryEnum`；
+- 标注 `@OpenSabreDictionary`。
+
+枚举声明顺序默认作为 `sort`，实现 `DictionaryEnum.sort()` 可覆盖顺序，`tagType()` 可设置标签类型。
+已有的 `DictionaryProvider` 仍然兼容，适用于动态字典、非枚举字典或需要自定义转换的场景。
+
 ```java
 @Bean
 DictionaryProvider orderDictionaryProvider() {
@@ -36,6 +78,32 @@ String label = dictionaryService.labelOf("order_status", value).orElse("未知�
 boolean valid = dictionaryService.contains("order_status", value);
 dictionaryService.refresh("order_status");
 ```
+
+从 0.7.6 开始，接口 DTO 可以直接使用字典约束校验启用项：
+
+```java
+public record CreateUserRequest(
+        @NotBlank
+        @DictionaryValue(value = "gender", message = "性别必须是有效字典项")
+        String gender) {
+}
+```
+
+Controller 继续使用标准 Jakarta Validation：
+
+```java
+@PostMapping
+public Result<Boolean> create(@Valid @RequestBody CreateUserRequest request) {
+    // ...
+}
+```
+
+`@DictionaryValue` 复用 `DictionaryService.contains`，因此只接受启用项并自动使用本地字典缓存。
+空值不由该注解处理，应按字段要求组合 `@NotNull`、`@NotBlank` 等标准约束。Sysadmin 不可用时
+保留 `DictionaryUnavailableException`，不能把基础设施故障伪装成普通参数非法。默认 WebMVC
+全局异常处理区分两类结果：值不属于启用项时返回 `ARGUMENT_NOT_VALID`；字典加载异常被校验引擎
+包装后返回 HTTP 503 和 `SYSTEM_BUSY`。Controller 参数与方法级校验产生的
+`HandlerMethodValidationException`、`ConstraintViolationException` 也统一映射为参数校验错误。
 
 - `items` 只返回启用项。
 - `labelOf` 包含停用项，用于历史值回显。
@@ -55,3 +123,57 @@ Framework 客户端约定：
 
 `base-sysadmin` 已实现以上治理协议。应用启动注册采用尽力而为语义：注册失败会记录日志，
 但不会阻止应用启动；读取失败仍抛出 `DictionaryUnavailableException`，由业务决定降级策略。
+
+## 后端工作流程
+
+### 1. 应用声明
+
+业务应用通过一个或多个 `DictionaryProvider` Bean 声明自己拥有的字典。Framework 会收集所有
+Provider，以 `dictCode` 合并定义；同一应用内出现内容不同的重复编码时，注册任务失败并记录冲突，
+不会向 Sysadmin 发送不确定的定义。
+
+应用只声明稳定的业务值、展示标签、排序和标签样式，不在本地建立平行的字典持久化模型。需要由
+运营人员维护、且不属于某个应用的字典，继续由 Sysadmin 字典管理功能维护。
+
+### 2. 启动注册
+
+应用触发 `ApplicationReadyEvent` 后，`DictionaryRegistrationListener` 执行以下步骤：
+
+1. 汇总所有 `DictionaryProvider`；没有 Provider 时不发起请求。
+2. 从 `spring.application.name` 取得应用名并生成完整字典快照。
+3. 通过 `SysadminGovernanceClient` 调用 `POST /dicts/snapshots`。
+4. 在 `X-Opensabre-Dictionary-Token` 请求头携带注册凭据。
+5. 交由通用治理注册运行时执行有限次数、指数退避且带抖动的重试。
+
+注册采用 fail-open 语义：Sysadmin 暂时不可用不会阻止业务应用启动。注册结果、尝试次数和最近错误
+由治理注册运行时记录，日志中的 `Governance registration task succeeded: task=dictionary` 表示本轮完成。
+
+```text
+DictionaryProvider
+        │
+        ▼
+ApplicationReadyEvent
+        │
+        ▼
+合并应用完整快照 ──注册 Token──▶ Sysadmin /dicts/snapshots
+```
+
+### 3. 运行时读取
+
+`DictionaryService` 默认由 `JetCacheDictionaryService` 实现。每个应用使用
+`governance:dictionary:{dictCode}` 本地缓存，缓存未命中时读取
+`GET /dicts/{dictCode}/items/all`，将包含停用项的完整结果缓存后再按调用语义过滤：
+
+- `items`：只返回启用项，适合选项列表。
+- `contains`：只认可启用项，适合新数据校验。
+- `labelOf`：包含停用项，保证历史业务值仍可回显。
+- `refresh`：删除指定字典的本地缓存，下次访问重新加载。
+
+本地缓存开启缓存击穿保护。远程加载失败会抛出 `DictionaryUnavailableException`；调用方必须把
+“字典服务不可用”和“业务值不合法”区分处理。
+
+### 4. 预热与刷新
+
+`preload-codes` 中的字典在应用就绪后预热。单个字典预热失败只记录警告，不影响其他字典和应用启动。
+当前版本没有完成 Sysadmin 变更向所有后端应用实时广播的闭环；变更通过短时缓存自然过期或显式调用
+`refresh(dictCode)` 生效。后续实时同步应发布包含 `dictCode` 的变更事件，由消费者精准清除本地缓存。

--- a/opensabre-starter-governance/pom.xml
+++ b/opensabre-starter-governance/pom.xml
@@ -65,6 +65,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/GovernanceProperties.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/GovernanceProperties.java
@@ -69,6 +69,8 @@ public class GovernanceProperties {
         private boolean registrationEnabled = false;
         private String registrationToken = "";
         private java.util.List<String> preloadCodes = java.util.List.of();
+        /** 自动扫描标准字典枚举的包；为空时使用 Spring Boot 应用自动配置包。 */
+        private java.util.List<String> scanPackages = java.util.List.of();
     }
 
     /**

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/OpensabreGovernanceConfig.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/config/OpensabreGovernanceConfig.java
@@ -9,6 +9,7 @@ import io.github.opensabre.governance.client.SysadminGovernanceClient;
 import io.github.opensabre.governance.errorcatalog.ErrorCatalogProvider;
 import io.github.opensabre.governance.errorcatalog.ErrorCatalogRegistrationListener;
 import io.github.opensabre.governance.dictionary.DictionaryProvider;
+import io.github.opensabre.governance.dictionary.ClasspathDictionaryEnumProvider;
 import io.github.opensabre.governance.dictionary.DictionaryRegistrationListener;
 import io.github.opensabre.governance.dictionary.DictionaryService;
 import io.github.opensabre.governance.dictionary.JetCacheDictionaryService;
@@ -27,6 +28,9 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages;
+import org.springframework.core.io.ResourceLoader;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -139,6 +143,22 @@ public class OpensabreGovernanceConfig {
             GovernanceRegistrationCoordinator registrationCoordinator) {
         return new DictionaryRegistrationListener(
                 clientProvider, providers, environment, registrationCoordinator);
+    }
+
+    @Bean
+    @ConditionalOnProperty(prefix = "opensabre.governance.dictionary", name = "enabled",
+            havingValue = "true", matchIfMissing = true)
+    public DictionaryProvider dictionaryEnumProvider(
+            ResourceLoader resourceLoader,
+            BeanFactory beanFactory,
+            GovernanceProperties properties) {
+        List<String> scanPackages = properties.getDictionary().getScanPackages();
+        if (scanPackages == null || scanPackages.isEmpty()) {
+            scanPackages = AutoConfigurationPackages.has(beanFactory)
+                    ? AutoConfigurationPackages.get(beanFactory)
+                    : List.of();
+        }
+        return new ClasspathDictionaryEnumProvider(resourceLoader, scanPackages);
     }
 
     @Bean

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/ClasspathDictionaryEnumProvider.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/ClasspathDictionaryEnumProvider.java
@@ -1,0 +1,75 @@
+package io.github.opensabre.governance.dictionary;
+
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+import org.springframework.util.ClassUtils;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * 从应用包中发现标准字典枚举并转换为现有 {@link DictionaryProvider} 模型。
+ */
+public final class ClasspathDictionaryEnumProvider implements DictionaryProvider {
+
+    private final ResourceLoader resourceLoader;
+    private final List<String> basePackages;
+
+    public ClasspathDictionaryEnumProvider(ResourceLoader resourceLoader, Collection<String> basePackages) {
+        this.resourceLoader = resourceLoader;
+        this.basePackages = basePackages == null
+                ? List.of()
+                : basePackages.stream()
+                        .filter(packageName -> packageName != null && !packageName.isBlank())
+                        .map(String::trim)
+                        .distinct()
+                        .sorted()
+                        .toList();
+    }
+
+    @Override
+    public Collection<DictionaryDefinition> dictionaries() {
+        if (basePackages.isEmpty()) {
+            return List.of();
+        }
+
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.setResourceLoader(resourceLoader);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(OpenSabreDictionary.class));
+        Set<String> classNames = new LinkedHashSet<>();
+        for (String basePackage : basePackages) {
+            scanner.findCandidateComponents(basePackage).stream()
+                    .map(beanDefinition -> beanDefinition.getBeanClassName())
+                    .filter(className -> className != null)
+                    .forEach(classNames::add);
+        }
+
+        return classNames.stream()
+                .sorted()
+                .map(this::toDictionaryDefinition)
+                .toList();
+    }
+
+    private DictionaryDefinition toDictionaryDefinition(String className) {
+        try {
+            Class<?> enumType = ClassUtils.forName(className, resourceLoader.getClassLoader());
+            OpenSabreDictionary metadata = enumType.getAnnotation(OpenSabreDictionary.class);
+            if (!enumType.isEnum() || !DictionaryEnum.class.isAssignableFrom(enumType)) {
+                throw new IllegalStateException(
+                        "@OpenSabreDictionary requires an enum implementing DictionaryEnum: " + className);
+            }
+            return createDefinition(metadata, enumType);
+        } catch (ClassNotFoundException | LinkageError exception) {
+            throw new IllegalStateException("Failed to load dictionary enum " + className, exception);
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private DictionaryDefinition createDefinition(OpenSabreDictionary metadata, Class<?> enumType) {
+        return DictionaryDefinition.of(metadata.code(), metadata.name(), (Class) enumType);
+    }
+}

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryDefinition.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryDefinition.java
@@ -24,4 +24,26 @@ public record DictionaryDefinition(String dictCode, String dictName, List<Dictio
                 .toList();
         return new DictionaryDefinition(code, name, items);
     }
+
+    /**
+     * 将实现标准字典接口的枚举转换为字典定义。
+     *
+     * @param code 字典编码
+     * @param name 字典名称
+     * @param enumType 标准字典枚举类型
+     * @param <E> 枚举类型
+     * @return 字典定义
+     */
+    public static <E extends Enum<E> & DictionaryEnum> DictionaryDefinition of(
+            String code, String name, Class<E> enumType) {
+        E[] values = enumType.getEnumConstants();
+        List<DictionaryItem> items = IntStream.range(0, values.length)
+                .mapToObj(index -> {
+                    E item = values[index];
+                    Integer sort = item.sort() == null ? index + 1 : item.sort();
+                    return new DictionaryItem(item.value(), item.label(), sort, item.tagType(), 1);
+                })
+                .toList();
+        return new DictionaryDefinition(code, name, items);
+    }
 }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryEnum.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryEnum.java
@@ -1,0 +1,41 @@
+package io.github.opensabre.governance.dictionary;
+
+/**
+ * OpenSabre 标准字典枚举契约。
+ *
+ * <p>实现该接口并使用 {@link OpenSabreDictionary} 标注后，Framework 会在应用启动时自动发现并上报。</p>
+ */
+public interface DictionaryEnum {
+
+    /**
+     * 字典值，保存到业务数据中的稳定值。
+     *
+     * @return 字典值
+     */
+    String value();
+
+    /**
+     * 字典展示标签。
+     *
+     * @return 展示标签
+     */
+    String label();
+
+    /**
+     * 可选展示顺序；返回 {@code null} 时使用枚举声明顺序。
+     *
+     * @return 展示顺序
+     */
+    default Integer sort() {
+        return null;
+    }
+
+    /**
+     * Element Plus 等前端使用的标签类型编码。
+     *
+     * @return 标签类型编码
+     */
+    default String tagType() {
+        return "N";
+    }
+}

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryUnavailableException.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/DictionaryUnavailableException.java
@@ -1,9 +1,12 @@
 package io.github.opensabre.governance.dictionary;
 
+import io.github.opensabre.common.core.exception.BaseException;
+import io.github.opensabre.common.core.exception.SystemErrorType;
+
 /** 字典中心不可用或响应异常。 */
-public class DictionaryUnavailableException extends RuntimeException {
+public class DictionaryUnavailableException extends BaseException {
 
     public DictionaryUnavailableException(String dictCode, Throwable cause) {
-        super("Failed to load dictionary " + dictCode, cause);
+        super(SystemErrorType.SYSTEM_BUSY, "Failed to load dictionary " + dictCode, cause);
     }
 }

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/OpenSabreDictionary.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/OpenSabreDictionary.java
@@ -1,0 +1,30 @@
+package io.github.opensabre.governance.dictionary;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 标记一个应自动注册到字典中心的枚举。
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface OpenSabreDictionary {
+
+    /**
+     * 全局字典编码。
+     *
+     * @return 字典编码
+     */
+    String code();
+
+    /**
+     * 字典展示名称。
+     *
+     * @return 字典名称
+     */
+    String name();
+}

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/validation/DictionaryValue.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/validation/DictionaryValue.java
@@ -1,0 +1,49 @@
+package io.github.opensabre.governance.dictionary.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * 校验字段值是否属于指定字典的启用项。
+ *
+ * <p>空值由 {@code @NotNull} 或 {@code @NotBlank} 等标准约束负责；字典加载失败时保留
+ * {@link io.github.opensabre.governance.dictionary.DictionaryUnavailableException}，避免把基础设施故障
+ * 误报为业务值非法。</p>
+ *
+ * @since 0.7.6
+ */
+@Target({METHOD, FIELD, ANNOTATION_TYPE, PARAMETER, TYPE_USE})
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = DictionaryValueValidator.class)
+public @interface DictionaryValue {
+
+    /**
+     * 待校验的字典编码。
+     *
+     * @return 字典编码
+     */
+    String value();
+
+    /**
+     * 校验失败提示。
+     *
+     * @return 提示信息
+     */
+    String message() default "必须是字典 {value} 中的启用项";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/validation/DictionaryValueValidator.java
+++ b/opensabre-starter-governance/src/main/java/io/github/opensabre/governance/dictionary/validation/DictionaryValueValidator.java
@@ -1,0 +1,43 @@
+package io.github.opensabre.governance.dictionary.validation;
+
+import io.github.opensabre.governance.dictionary.DictionaryService;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * 使用统一 {@link DictionaryService} 校验请求字段，复用其启用项和缓存语义。
+ */
+public class DictionaryValueValidator implements ConstraintValidator<DictionaryValue, Object> {
+
+    private final DictionaryService dictionaryService;
+    private String dictCode;
+
+    /**
+     * 创建字典值校验器。
+     *
+     * @param dictionaryService Framework 字典读取服务
+     */
+    public DictionaryValueValidator(DictionaryService dictionaryService) {
+        this.dictionaryService = dictionaryService;
+    }
+
+    @Override
+    public void initialize(DictionaryValue constraintAnnotation) {
+        dictCode = constraintAnnotation.value();
+    }
+
+    /**
+     * 空值交给标准空值约束；非空值必须属于字典启用项。
+     *
+     * @param value 待校验值
+     * @param context 校验上下文
+     * @return 是否有效
+     */
+    @Override
+    public boolean isValid(Object value, ConstraintValidatorContext context) {
+        if (value == null || value instanceof CharSequence text && text.toString().isBlank()) {
+            return true;
+        }
+        return dictionaryService.contains(dictCode, value);
+    }
+}

--- a/opensabre-starter-governance/src/main/resources/opensabre-governance.yml
+++ b/opensabre-starter-governance/src/main/resources/opensabre-governance.yml
@@ -31,3 +31,4 @@ opensabre:
       registration-enabled: true
       registration-token: ${DICTIONARY_REGISTRATION_TOKEN:${GOVERNANCE_REGISTRATION_TOKEN:${ERROR_CATALOG_REGISTRATION_TOKEN:}}}
       preload-codes: []
+      scan-packages: []

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/AnnotatedDictionary.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/AnnotatedDictionary.java
@@ -1,0 +1,39 @@
+package io.github.opensabre.governance.dictionary;
+
+@OpenSabreDictionary(code = "scan_status", name = "扫描状态")
+enum AnnotatedDictionary implements DictionaryEnum {
+    ENABLED("enabled", "启用"),
+    DISABLED("disabled", "停用");
+
+    private final String value;
+    private final String label;
+
+    AnnotatedDictionary(String value, String label) {
+        this.value = value;
+        this.label = label;
+    }
+
+    @Override
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String label() {
+        return label;
+    }
+}
+
+enum UnannotatedDictionary implements DictionaryEnum {
+    VALUE;
+
+    @Override
+    public String value() {
+        return "value";
+    }
+
+    @Override
+    public String label() {
+        return "值";
+    }
+}

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/ClasspathDictionaryEnumProviderTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/ClasspathDictionaryEnumProviderTest.java
@@ -1,0 +1,37 @@
+package io.github.opensabre.governance.dictionary;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClasspathDictionaryEnumProviderTest {
+
+    @Test
+    void discoversAnnotatedStandardEnumInConfiguredPackage() {
+        ClasspathDictionaryEnumProvider provider = new ClasspathDictionaryEnumProvider(
+                new DefaultResourceLoader(), List.of("io.github.opensabre.governance.dictionary"));
+
+        List<DictionaryDefinition> definitions = provider.dictionaries().stream().toList();
+
+        assertEquals(1, definitions.size());
+        DictionaryDefinition definition = definitions.stream()
+                .filter(item -> item.dictCode().equals("scan_status"))
+                .findFirst()
+                .orElseThrow();
+        assertEquals("扫描状态", definition.dictName());
+        assertEquals("enabled", definition.items().get(0).value());
+        assertEquals(2, definition.items().size());
+    }
+
+    @Test
+    void doesNotScanWhenNoPackageIsConfigured() {
+        ClasspathDictionaryEnumProvider provider = new ClasspathDictionaryEnumProvider(
+                new DefaultResourceLoader(), List.of());
+
+        assertTrue(provider.dictionaries().isEmpty());
+    }
+}

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/DictionaryDefinitionTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/DictionaryDefinitionTest.java
@@ -16,6 +16,17 @@ class DictionaryDefinitionTest {
         assertEquals("正常", definition.items().get(0).label());
     }
 
+    @Test
+    void adaptsStandardDictionaryEnum() {
+        DictionaryDefinition definition = DictionaryDefinition.of(
+                "standard_status", "标准状态", StandardStatus.class);
+
+        assertEquals("enabled", definition.items().get(0).value());
+        assertEquals("启用", definition.items().get(0).label());
+        assertEquals(10, definition.items().get(1).sort());
+        assertEquals("S", definition.items().get(1).tagType());
+    }
+
     private enum Status {
         ENABLED("1", "正常"),
         DISABLED("0", "禁用");
@@ -34,6 +45,39 @@ class DictionaryDefinitionTest {
 
         String label() {
             return label;
+        }
+    }
+
+    private enum StandardStatus implements DictionaryEnum {
+        ENABLED("enabled", "启用"),
+        DISABLED("disabled", "停用");
+
+        private final String value;
+        private final String label;
+
+        StandardStatus(String value, String label) {
+            this.value = value;
+            this.label = label;
+        }
+
+        @Override
+        public String value() {
+            return value;
+        }
+
+        @Override
+        public String label() {
+            return label;
+        }
+
+        @Override
+        public Integer sort() {
+            return this == DISABLED ? 10 : 1;
+        }
+
+        @Override
+        public String tagType() {
+            return this == DISABLED ? "S" : "N";
         }
     }
 }

--- a/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/validation/DictionaryValueValidatorTest.java
+++ b/opensabre-starter-governance/src/test/java/io/github/opensabre/governance/dictionary/validation/DictionaryValueValidatorTest.java
@@ -1,0 +1,108 @@
+package io.github.opensabre.governance.dictionary.validation;
+
+import io.github.opensabre.governance.dictionary.DictionaryService;
+import io.github.opensabre.governance.dictionary.DictionaryUnavailableException;
+import jakarta.validation.ConstraintViolation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+import org.springframework.validation.beanvalidation.SpringConstraintValidatorFactory;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class DictionaryValueValidatorTest {
+
+    private DictionaryService dictionaryService;
+    private DictionaryValueValidator validator;
+
+    @BeforeEach
+    void setUp() {
+        dictionaryService = mock(DictionaryService.class);
+        validator = new DictionaryValueValidator(dictionaryService);
+        validator.initialize(TestRequest.class.getDeclaredFields()[0].getAnnotation(DictionaryValue.class));
+    }
+
+    @Test
+    void acceptsNullAndBlankValuesForStandardConstraintsToHandle() {
+        assertThat(validator.isValid(null, null)).isTrue();
+        assertThat(validator.isValid("  ", null)).isTrue();
+        verifyNoInteractions(dictionaryService);
+    }
+
+    @Test
+    void acceptsEnabledDictionaryValue() {
+        when(dictionaryService.contains("gender", "F")).thenReturn(true);
+
+        assertThat(validator.isValid("F", null)).isTrue();
+    }
+
+    @Test
+    void rejectsValueOutsideEnabledDictionaryItems() {
+        when(dictionaryService.contains("gender", "UNKNOWN")).thenReturn(false);
+
+        assertThat(validator.isValid("UNKNOWN", null)).isFalse();
+    }
+
+    @Test
+    void preservesDictionaryUnavailableFailure() {
+        DictionaryUnavailableException unavailable =
+                new DictionaryUnavailableException("gender", new IllegalStateException("sysadmin unavailable"));
+        when(dictionaryService.contains("gender", "F")).thenThrow(unavailable);
+
+        assertThatThrownBy(() -> validator.isValid("F", null)).isSameAs(unavailable);
+    }
+
+    @Test
+    void integratesWithSpringConstraintValidatorFactory() {
+        when(dictionaryService.contains("gender", "UNKNOWN")).thenReturn(false);
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("dictionaryService", dictionaryService);
+        LocalValidatorFactoryBean validatorFactory = new LocalValidatorFactoryBean();
+        validatorFactory.setConstraintValidatorFactory(new SpringConstraintValidatorFactory(beanFactory));
+        validatorFactory.afterPropertiesSet();
+
+        Set<ConstraintViolation<TestRequest>> violations =
+                validatorFactory.validate(new TestRequest("UNKNOWN"));
+
+        assertThat(violations).singleElement()
+                .extracting(ConstraintViolation::getMessage)
+                .isEqualTo("必须是字典 gender 中的启用项");
+        validatorFactory.close();
+    }
+
+    @Test
+    void springValidationWrapsDictionaryUnavailableForGlobalHandling() {
+        DictionaryUnavailableException unavailable =
+                new DictionaryUnavailableException("gender", new IllegalStateException("sysadmin unavailable"));
+        when(dictionaryService.contains("gender", "F")).thenThrow(unavailable);
+        DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+        beanFactory.registerSingleton("dictionaryService", dictionaryService);
+        LocalValidatorFactoryBean validatorFactory = new LocalValidatorFactoryBean();
+        validatorFactory.setConstraintValidatorFactory(new SpringConstraintValidatorFactory(beanFactory));
+        validatorFactory.afterPropertiesSet();
+
+        assertThatThrownBy(() -> validatorFactory.validate(new TestRequest("F")))
+                .isInstanceOf(jakarta.validation.ValidationException.class)
+                .hasCauseInstanceOf(DictionaryUnavailableException.class);
+        validatorFactory.close();
+    }
+
+    private static class TestRequest {
+        @DictionaryValue("gender")
+        private String gender;
+
+        private TestRequest() {
+        }
+
+        private TestRequest(String gender) {
+            this.gender = gender;
+        }
+    }
+}

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/webmvc/exception/DefaultWebMvcExceptionHandlerAdvice.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/webmvc/exception/DefaultWebMvcExceptionHandlerAdvice.java
@@ -4,9 +4,13 @@ import io.github.opensabre.common.core.entity.vo.Result;
 import io.github.opensabre.common.core.exception.SystemErrorType;
 import jakarta.servlet.ServletException;
 import io.github.opensabre.common.core.exception.BaseException;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ValidationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -19,6 +23,9 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+
+import java.util.Optional;
 
 /**
  * 默认全局异常处理类
@@ -38,6 +45,37 @@ public class DefaultWebMvcExceptionHandlerAdvice {
     public Result<?> argumentInvalidException(MethodArgumentNotValidException ex) {
         log.warn("service exception:{}", ex.getMessage());
         return Result.fail(SystemErrorType.ARGUMENT_NOT_VALID, ex.getBindingResult().getFieldError().getDefaultMessage());
+    }
+
+    @ExceptionHandler(value = {HandlerMethodValidationException.class})
+    public Result<?> handlerMethodValidationException(HandlerMethodValidationException ex) {
+        log.warn("handler method validation exception:{}", ex.getMessage());
+        return Result.fail(SystemErrorType.ARGUMENT_NOT_VALID, ex.getMessage());
+    }
+
+    @ExceptionHandler(value = {ConstraintViolationException.class})
+    public Result<?> constraintViolationException(ConstraintViolationException ex) {
+        log.warn("constraint violation exception:{}", ex.getMessage());
+        String message = ex.getConstraintViolations().stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()
+                .orElse(ex.getMessage());
+        return Result.fail(SystemErrorType.ARGUMENT_NOT_VALID, message);
+    }
+
+    /**
+     * 处理校验器执行期间的基础设施异常，例如字典中心不可用。
+     */
+    @ExceptionHandler(value = {ValidationException.class})
+    public ResponseEntity<Result<?>> validationException(ValidationException ex) {
+        Optional<BaseException> baseException = findCause(ex, BaseException.class);
+        if (baseException.isPresent()) {
+            log.error("validation dependency unavailable: {}", baseException.get().getMessage(), ex);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+                    .body(Result.fail(baseException.get().getErrorType()));
+        }
+        log.error("validation engine exception", ex);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Result.fail());
     }
 
     @ExceptionHandler(value = {HttpMessageNotReadableException.class, MethodArgumentTypeMismatchException.class})
@@ -84,5 +122,16 @@ public class DefaultWebMvcExceptionHandlerAdvice {
     public Result<?> exception(Throwable ex) {
         log.error("exception: ", ex);
         return Result.fail();
+    }
+
+    private <T extends Throwable> Optional<T> findCause(Throwable throwable, Class<T> causeType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (causeType.isInstance(current)) {
+                return Optional.of(causeType.cast(current));
+            }
+            current = current.getCause();
+        }
+        return Optional.empty();
     }
 }

--- a/opensabre-starter-webmvc/src/test/java/io/github/opensabre/webmvc/exception/DefaultWebMvcExceptionHandlerAdviceTest.java
+++ b/opensabre-starter-webmvc/src/test/java/io/github/opensabre/webmvc/exception/DefaultWebMvcExceptionHandlerAdviceTest.java
@@ -3,6 +3,9 @@ package io.github.opensabre.webmvc.exception;
 import io.github.opensabre.common.core.entity.vo.Result;
 import io.github.opensabre.common.core.exception.BaseException;
 import io.github.opensabre.common.core.exception.SystemErrorType;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ValidationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.MethodParameter;
@@ -12,8 +15,12 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.multipart.MultipartException;
 
+import java.util.Set;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class DefaultWebMvcExceptionHandlerAdviceTest {
 
@@ -55,6 +62,29 @@ class DefaultWebMvcExceptionHandlerAdviceTest {
     void baseExceptionShouldReturnOriginalErrorType() {
         Result<?> result = advice.baseException(new BaseException(SystemErrorType.SYSTEM_BUSY));
         assertEquals(SystemErrorType.SYSTEM_BUSY.getCode(), result.getCode());
+    }
+
+    @Test
+    void constraintViolationShouldReturnArgumentInvalidMessage() {
+        ConstraintViolation<?> violation = mock(ConstraintViolation.class);
+        when(violation.getMessage()).thenReturn("性别必须是有效字典项");
+        ConstraintViolationException exception = new ConstraintViolationException(Set.of(violation));
+
+        Result<?> result = advice.constraintViolationException(exception);
+
+        assertEquals(SystemErrorType.ARGUMENT_NOT_VALID.getCode(), result.getCode());
+        assertEquals(SystemErrorType.ARGUMENT_NOT_VALID.getMesg() + "：性别必须是有效字典项", result.getMesg());
+    }
+
+    @Test
+    void validationDependencyFailureShouldReturnServiceUnavailable() {
+        BaseException unavailable = new BaseException(SystemErrorType.SYSTEM_BUSY, "dictionary unavailable");
+        ValidationException exception = new ValidationException("validator failed", unavailable);
+
+        var response = advice.validationException(exception);
+
+        assertEquals(503, response.getStatusCode().value());
+        assertEquals(SystemErrorType.SYSTEM_BUSY.getCode(), response.getBody().getCode());
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>0.7.5</revision>
+        <revision>0.7.6-SNAPSHOT</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
## 变更说明
- 自动扫描实现 `DictionaryEnum` 且标注 `@OpenSabreDictionary` 的枚举并接入现有字典注册模型
- 增加 `@DictionaryValue` 字典启用项校验
- WebMVC 区分业务校验失败与字典依赖不可用
- 补充模块文档和单元测试

## 验证
- `mvn clean install`
- `mvn -B package javadoc:javadoc --file pom.xml`
- `examples/sample-boot` 使用本地 `0.7.6-SNAPSHOT` 启动完整 Spring Boot 上下文，验证枚举自动发现、注册定义及字典值校验