### PR TITLE
chore: 发布 Framework 0.7.6

### DIFF
--- a/docs/modules/dictionary.md
+++ b/docs/modules/dictionary.md
@@ -1,6 +1,6 @@
 # 字典治理组件
 
-`opensabre-starter-governance` 0.7.6-SNAPSHOT 提供应用侧字典声明、启动注册、预热和本地缓存读取能力。
+`opensabre-starter-governance` 0.7.6 提供应用侧字典声明、启动注册、预热和本地缓存读取能力。
 
 ## 配置
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>0.7.6-SNAPSHOT</revision>
+        <revision>0.7.6</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
## 发布内容
- 将 Framework 版本从 `0.7.6-SNAPSHOT` 固化为 `0.7.6`
- 同步字典治理模块文档版本标识

## 发布前验证
- `mvn clean install`（正式 0.7.6，15 个模块全部通过）
- 功能 PR #53 CI 通过
- `examples/sample-boot` 完整 Spring Boot 上下文验证通过