### PR TITLE
fix: 自动完成 Maven Central 发布

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,8 @@
                     <extensions>true</extensions>
                     <configuration>
                         <publishingServerId>ossrh</publishingServerId>
+                        <autoPublish>true</autoPublish>
+                        <waitUntil>published</waitUntil>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## 问题
0.7.6 发布工作流上传并验证 Central Deployment 后即成功退出，实际仍停留在 `VALIDATED`，需要人工 publish。

## 修复
- 配置 `autoPublish=true`
- 配置 `waitUntil=published`，让 CI 只有在 Central 真正发布完成后才成功

## 验证
- `mvn help:effective-pom` 确认所有模块继承上述配置
- 0.7.6 部署已通过 Sonatype Publisher API 补充发布并确认 `PUBLISHED`