### PR TITLE
feat: 支持内部 Token 热刷新与用户上下文绑定

### DIFF
--- a/docs/modules/security-internal-token.md
+++ b/docs/modules/security-internal-token.md
@@ -60,9 +60,12 @@ opensabre:
 平台公共配置统一存放在 `opensabre-common.yml`，Data ID 和 Group 可分别用
 `OPENSABRE_COMMON_CONFIG_DATA_ID`、`OPENSABRE_COMMON_CONFIG_GROUP` 覆盖。
 
-当前公共配置在应用 Bootstrap 阶段加载，尚不支持热刷新。轮换后必须按接收方优先、
-调用方随后滚动重启全部相关应用；确认每个实例均加载新的 `key-config-version` 后，
-previous 仍须至少保留最大 Token 生命周期与时钟偏差之和，之后才能退役。
+安全 Starter 在 Bootstrap 阶段加载公共配置，并订阅 Nacos 后续变更。候选配置只有在
+完整解析、密钥和时效参数校验通过且 `key-config-version` 未倒退时才会原子替换；
+失败时继续使用上一份有效快照。每个实例通过 Actuator
+`/actuator/internalTokenKeyStatus` 暴露不含密钥的版本、active key ID 和刷新状态。
+previous 仍须至少保留最大 Token 生命周期与时钟偏差之和，并在所有目标实例确认
+加载新版本后才能退役。
 
 ## Claims
 
@@ -228,6 +231,8 @@ RestClient orderRestClient(RestClient.Builder builder) {
 ## 安全约束
 
 - 不在代码库、日志、审计记录或管理页面返回共享密钥和完整 Token。
+- 外部 JWT 首跳在 Spring Security 完成验证后自动绑定 `UserContextHolder`，供审计与
+  持久化元数据使用；不信任客户端自报用户名 Header。
 - `enabled` 默认关闭；应用完成共享密钥配置和调用链验证后再显式开启。
 - 共享 HMAC 意味着任一持有密钥的应用理论上具有全局签发能力，需要配合网络隔离、
   最小配置读取权限、短 TTL、快速轮换和完整审计。

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenConfigurationRefresher.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenConfigurationRefresher.java
@@ -1,0 +1,114 @@
+package io.github.opensabre.security.config;
+
+import com.alibaba.cloud.nacos.NacosConfigManager;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.listener.Listener;
+import io.github.opensabre.security.token.HmacKeyRing;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources;
+import org.springframework.boot.env.YamlPropertySourceLoader;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.ByteArrayResource;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class InternalTokenConfigurationRefresher implements SmartLifecycle {
+    private static final Logger log = LoggerFactory.getLogger(InternalTokenConfigurationRefresher.class);
+    private static final String PREFIX = "opensabre.security.internal-token";
+    private final ConfigService configService;
+    private final InternalTokenProperties properties;
+    private final String dataId;
+    private final String group;
+    private final AtomicReference<InternalTokenRefreshStatus> status;
+    private final Listener listener = new Listener() {
+        @Override public Executor getExecutor() { return null; }
+        @Override public void receiveConfigInfo(String configInfo) { refresh(configInfo); }
+    };
+    private volatile boolean running;
+
+    public InternalTokenConfigurationRefresher(NacosConfigManager configManager,
+                                               InternalTokenProperties properties,
+                                               String dataId, String group) {
+        this.configService = configManager.getConfigService();
+        this.properties = properties;
+        this.dataId = dataId;
+        this.group = group;
+        InternalTokenProperties initial = properties.snapshot();
+        this.status = new AtomicReference<>(new InternalTokenRefreshStatus(
+                initial.getKeyConfigVersion(), initial.getActiveKeyId(), Instant.now(), true, "initial"));
+    }
+
+    @Override public void start() {
+        try {
+            configService.addListener(dataId, group, listener);
+            running = true;
+            log.info("Subscribed to internal-token configuration {}/{}", group, dataId);
+        } catch (Exception exception) {
+            throw new IllegalStateException("Cannot subscribe to internal-token configuration", exception);
+        }
+    }
+
+    @Override public void stop() {
+        configService.removeListener(dataId, group, listener);
+        running = false;
+    }
+
+    @Override public boolean isRunning() { return running; }
+    public InternalTokenRefreshStatus currentStatus() { return status.get(); }
+
+    void refresh(String yaml) {
+        InternalTokenProperties before = properties.snapshot();
+        try {
+            InternalTokenProperties candidate = bind(yaml);
+            validate(candidate);
+            if (candidate.getKeyConfigVersion() < before.getKeyConfigVersion()) {
+                throw new IllegalArgumentException("key-config-version must not decrease");
+            }
+            if (candidate.getKeyConfigVersion() == before.getKeyConfigVersion()) {
+                return;
+            }
+            properties.replaceWith(candidate);
+            status.set(new InternalTokenRefreshStatus(candidate.getKeyConfigVersion(),
+                    candidate.getActiveKeyId(), Instant.now(), true, "refreshed"));
+            log.info("Refreshed internal-token configuration: version={}, activeKeyId={}",
+                    candidate.getKeyConfigVersion(), candidate.getActiveKeyId());
+        } catch (Exception exception) {
+            status.set(new InternalTokenRefreshStatus(before.getKeyConfigVersion(), before.getActiveKeyId(),
+                    Instant.now(), false, exception.getMessage()));
+            log.error("Rejected internal-token configuration refresh; keeping version {}: {}",
+                    before.getKeyConfigVersion(), exception.getMessage());
+        }
+    }
+
+    private static InternalTokenProperties bind(String yaml) throws Exception {
+        MutablePropertySources sources = new MutablePropertySources();
+        for (PropertySource<?> source : new YamlPropertySourceLoader().load("opensabreInternalTokenRefresh",
+                new ByteArrayResource(yaml.getBytes(StandardCharsets.UTF_8)))) {
+            sources.addLast(source);
+        }
+        return new Binder(ConfigurationPropertySources.from(sources)).bind(PREFIX,
+                Bindable.of(InternalTokenProperties.class)).orElseThrow(
+                () -> new IllegalArgumentException("internal-token configuration is missing"));
+    }
+
+    private static void validate(InternalTokenProperties candidate) {
+        if (!candidate.isEnabled()) return;
+        new HmacKeyRing(candidate);
+        long ttl = candidate.getTtl().toSeconds();
+        long maxTtl = candidate.getMaxTtl().toSeconds();
+        if (ttl <= 0 || maxTtl <= 0 || ttl > maxTtl || maxTtl > 120) {
+            throw new IllegalArgumentException("ttl/max-ttl configuration is invalid");
+        }
+        if (candidate.getClockSkew().isNegative() || candidate.getMaxHop() <= 0) {
+            throw new IllegalArgumentException("clock-skew/max-hop configuration is invalid");
+        }
+    }
+}

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenProperties.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenProperties.java
@@ -56,4 +56,33 @@ public class InternalTokenProperties {
     private Set<String> allowedExtensionKeys = new LinkedHashSet<>();
     private Set<String> excludedPaths = new LinkedHashSet<>(Set.of(
             "/actuator/**", "/v3/**", "/doc.html", "/webjars/**", "/assets/**"));
+
+    public synchronized InternalTokenProperties snapshot() {
+        InternalTokenProperties copy = new InternalTokenProperties();
+        copy.replaceWith(this);
+        return copy;
+    }
+
+    public synchronized void replaceWith(InternalTokenProperties source) {
+        enabled = source.enabled;
+        restClientEnabled = source.restClientEnabled;
+        restClientAllowedTargets = new LinkedHashSet<>(source.restClientAllowedTargets);
+        required = source.required;
+        keyConfigVersion = source.keyConfigVersion;
+        activeKeyId = source.activeKeyId;
+        activeKey = source.activeKey;
+        previousKeyId = source.previousKeyId;
+        previousKey = source.previousKey;
+        activeKeyActivatedAt = source.activeKeyActivatedAt;
+        previousKeyRetireAfter = source.previousKeyRetireAfter;
+        ttl = source.ttl;
+        maxTtl = source.maxTtl;
+        clockSkew = source.clockSkew;
+        maxHop = source.maxHop;
+        maxTokenBytes = source.maxTokenBytes;
+        maxExtensionBytes = source.maxExtensionBytes;
+        allowedIssuers = new LinkedHashSet<>(source.allowedIssuers);
+        allowedExtensionKeys = new LinkedHashSet<>(source.allowedExtensionKeys);
+        excludedPaths = new LinkedHashSet<>(source.excludedPaths);
+    }
 }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenRefreshEndpoint.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenRefreshEndpoint.java
@@ -1,0 +1,18 @@
+package io.github.opensabre.security.config;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+
+@Endpoint(id = "internalTokenKeyStatus")
+public class InternalTokenRefreshEndpoint {
+    private final InternalTokenConfigurationRefresher refresher;
+
+    public InternalTokenRefreshEndpoint(InternalTokenConfigurationRefresher refresher) {
+        this.refresher = refresher;
+    }
+
+    @ReadOperation
+    public InternalTokenRefreshStatus status() {
+        return refresher.currentStatus();
+    }
+}

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenRefreshStatus.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/InternalTokenRefreshStatus.java
@@ -1,0 +1,7 @@
+package io.github.opensabre.security.config;
+
+import java.time.Instant;
+
+public record InternalTokenRefreshStatus(long configVersion, String activeKeyId, Instant refreshedAt,
+                                         boolean successful, String message) {
+}

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/OpensabreSecurityAutoConfiguration.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/config/OpensabreSecurityAutoConfiguration.java
@@ -1,6 +1,7 @@
 package io.github.opensabre.security.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.alibaba.cloud.nacos.NacosConfigManager;
 import io.github.opensabre.security.context.InternalTokenUserContext;
 import io.github.opensabre.security.key.InternalTokenKeyStatusProvider;
 import io.github.opensabre.security.key.PropertiesInternalTokenKeyStatusProvider;
@@ -11,6 +12,8 @@ import io.github.opensabre.security.token.InternalTokenService;
 import io.github.opensabre.security.token.InternalTokenRequestFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
@@ -53,5 +56,22 @@ public class OpensabreSecurityAutoConfiguration {
     public InternalTokenKeyStatusProvider internalTokenKeyStatusProvider(
             InternalTokenProperties properties) {
         return new PropertiesInternalTokenKeyStatusProvider(properties);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "opensabre.security.internal-token", name = "enabled", havingValue = "true")
+    public InternalTokenConfigurationRefresher internalTokenConfigurationRefresher(
+            NacosConfigManager configManager, InternalTokenProperties properties,
+            @Value("${OPENSABRE_COMMON_CONFIG_DATA_ID:opensabre-common.yml}") String dataId,
+            @Value("${OPENSABRE_COMMON_CONFIG_GROUP:DEFAULT_GROUP}") String group) {
+        return new InternalTokenConfigurationRefresher(configManager, properties, dataId, group);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    @ConditionalOnProperty(prefix = "opensabre.security.internal-token", name = "enabled", havingValue = "true")
+    public InternalTokenRefreshEndpoint internalTokenRefreshEndpoint(InternalTokenConfigurationRefresher refresher) {
+        return new InternalTokenRefreshEndpoint(refresher);
     }
 }

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/DefaultInternalTokenService.java
@@ -43,7 +43,8 @@ public class DefaultInternalTokenService implements InternalTokenService {
 
     @Override
     public String issue(InternalTokenRequest request) {
-        validateRequest(request);
+        InternalTokenProperties properties = this.properties.snapshot();
+        validateRequest(request, properties);
         HmacKeyRing keyRing = new HmacKeyRing(properties);
         long now = clock.instant().getEpochSecond();
         long ttl = properties.getTtl().toSeconds();
@@ -53,7 +54,7 @@ public class DefaultInternalTokenService implements InternalTokenService {
                     InternalTokenError.INVALID_CONFIGURATION,
                     "ttl must be positive, no greater than max-ttl, and max-ttl must not exceed 120 seconds");
         }
-        validateExtensions(request.extensions());
+        validateExtensions(request.extensions(), properties);
 
         Map<String, Object> header = new LinkedHashMap<>();
         header.put("alg", InternalTokenConstants.ALGORITHM);
@@ -99,6 +100,7 @@ public class DefaultInternalTokenService implements InternalTokenService {
 
     @Override
     public InternalTokenClaims verify(String token, String expectedAudience) {
+        InternalTokenProperties properties = this.properties.snapshot();
         if (token == null || token.isBlank()) {
             throw new InternalTokenException(InternalTokenError.MISSING_TOKEN, "internal token is missing");
         }
@@ -133,8 +135,8 @@ public class DefaultInternalTokenService implements InternalTokenService {
             }
             
             InternalTokenClaims claims = toClaims(decodeMap(parts[1]));
-            validateClaims(claims, expectedAudience);
-            validateExtensions(claims.extensions());
+            validateClaims(claims, expectedAudience, properties);
+            validateExtensions(claims.extensions(), properties);
             return claims;
         } catch (InternalTokenException exception) {
             throw exception;
@@ -143,7 +145,7 @@ public class DefaultInternalTokenService implements InternalTokenService {
         }
     }
 
-    private void validateRequest(InternalTokenRequest request) {
+    private void validateRequest(InternalTokenRequest request, InternalTokenProperties properties) {
         if (request == null
                 || !hasText(request.issuer())
                 || !hasText(request.subject())
@@ -168,7 +170,8 @@ public class DefaultInternalTokenService implements InternalTokenService {
         }
     }
 
-    private void validateClaims(InternalTokenClaims claims, String expectedAudience) {
+    private void validateClaims(InternalTokenClaims claims, String expectedAudience,
+                                InternalTokenProperties properties) {
         if (!hasText(expectedAudience)
                 || !expectedAudience.equals(claims.audience())
                 || !expectedAudience.equals(claims.destination())) {
@@ -201,7 +204,7 @@ public class DefaultInternalTokenService implements InternalTokenService {
         }
     }
 
-    private void validateExtensions(Map<String, Object> extensions) {
+    private void validateExtensions(Map<String, Object> extensions, InternalTokenProperties properties) {
         Set<String> allowedKeys = properties.getAllowedExtensionKeys();
         if (!extensions.isEmpty() && (allowedKeys.isEmpty() || !allowedKeys.containsAll(extensions.keySet()))) {
             throw new InternalTokenException(InternalTokenError.INVALID_EXTENSIONS, "extension key is not allowed");

--- a/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/HmacKeyRing.java
+++ b/opensabre-starter-security/src/main/java/io/github/opensabre/security/token/HmacKeyRing.java
@@ -9,7 +9,7 @@ import java.util.Map;
 /**
  * Immutable active/previous HMAC key snapshot.
  */
-final class HmacKeyRing {
+public final class HmacKeyRing {
 
     private static final int MINIMUM_KEY_BYTES = 32;
 
@@ -17,7 +17,7 @@ final class HmacKeyRing {
     private final byte[] activeKey;
     private final Map<String, byte[]> verificationKeys;
 
-    HmacKeyRing(InternalTokenProperties properties) {
+    public HmacKeyRing(InternalTokenProperties properties) {
         this.activeKeyId = requireText(properties.getActiveKeyId(), "active-key-id");
         this.activeKey = decodeKey(properties.getActiveKey(), "active-key");
         Map<String, byte[]> keys = new LinkedHashMap<>();

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/config/InternalTokenConfigurationRefresherTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/config/InternalTokenConfigurationRefresherTest.java
@@ -1,0 +1,74 @@
+package io.github.opensabre.security.config;
+
+import com.alibaba.cloud.nacos.NacosConfigManager;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Base64;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class InternalTokenConfigurationRefresherTest {
+    @Test
+    void acceptsHigherValidVersion() {
+        InternalTokenProperties properties = properties(1, "key-1");
+        InternalTokenConfigurationRefresher refresher = refresher(properties);
+        refresher.refresh(yaml(2, "key-2", key(2)));
+        assertThat(properties.getKeyConfigVersion()).isEqualTo(2);
+        assertThat(properties.getActiveKeyId()).isEqualTo("key-2");
+        assertThat(refresher.currentStatus().successful()).isTrue();
+    }
+
+    @Test
+    void rejectsInvalidKeyAndKeepsPreviousSnapshot() {
+        InternalTokenProperties properties = properties(1, "key-1");
+        InternalTokenConfigurationRefresher refresher = refresher(properties);
+        refresher.refresh(yaml(2, "key-2", Base64.getEncoder().encodeToString(new byte[8])));
+        assertThat(properties.getKeyConfigVersion()).isEqualTo(1);
+        assertThat(refresher.currentStatus().successful()).isFalse();
+    }
+
+    @Test
+    void rejectsOutOfOrderVersion() {
+        InternalTokenProperties properties = properties(3, "key-3");
+        InternalTokenConfigurationRefresher refresher = refresher(properties);
+        refresher.refresh(yaml(2, "key-2", key(2)));
+        assertThat(properties.getKeyConfigVersion()).isEqualTo(3);
+        assertThat(refresher.currentStatus().successful()).isFalse();
+    }
+
+    private static InternalTokenConfigurationRefresher refresher(InternalTokenProperties properties) {
+        NacosConfigManager manager = mock(NacosConfigManager.class);
+        when(manager.getConfigService()).thenReturn(mock(ConfigService.class));
+        return new InternalTokenConfigurationRefresher(manager, properties, "opensabre-common.yml", "DEFAULT_GROUP");
+    }
+
+    private static InternalTokenProperties properties(long version, String id) {
+        InternalTokenProperties properties = new InternalTokenProperties();
+        properties.setEnabled(true);
+        properties.setKeyConfigVersion(version);
+        properties.setActiveKeyId(id);
+        properties.setActiveKey(key((int) version));
+        properties.setTtl(Duration.ofSeconds(30));
+        properties.setMaxTtl(Duration.ofSeconds(60));
+        properties.setAllowedIssuers(Set.of("base-sysadmin"));
+        return properties;
+    }
+
+    private static String yaml(long version, String id, String encodedKey) {
+        return "opensabre:\n  security:\n    internal-token:\n      enabled: true\n"
+                + "      key-config-version: " + version + "\n      active-key-id: " + id + "\n"
+                + "      active-key: " + encodedKey + "\n      ttl: 30s\n      max-ttl: 60s\n"
+                + "      clock-skew: 5s\n      max-hop: 3\n      allowed-issuers: [base-sysadmin]\n";
+    }
+
+    private static String key(int seed) {
+        byte[] value = new byte[32];
+        java.util.Arrays.fill(value, (byte) seed);
+        return Base64.getEncoder().encodeToString(value);
+    }
+}

--- a/opensabre-starter-webmvc/src/main/java/io/github/opensabre/webmvc/config/OpensabreWebMvcConfig.java
+++ b/opensabre-starter-webmvc/src/main/java/io/github/opensabre/webmvc/config/OpensabreWebMvcConfig.java
@@ -4,10 +4,15 @@ import io.github.opensabre.webmvc.exception.DefaultWebMvcExceptionHandlerAdvice;
 import io.github.opensabre.webmvc.rest.RestResponseBodyAdvice;
 import io.github.opensabre.boot.config.OpensabreServiceConfig;
 import io.github.opensabre.boot.config.OpensabreSwaggerConfig;
+import io.github.opensabre.webmvc.interceptor.UserInterceptor;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.PropertySource;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /**
  * Opensabre WebMvc auto-configuration.
@@ -18,4 +23,20 @@ import org.springframework.context.annotation.PropertySource;
 @Import({DefaultWebMvcExceptionHandlerAdvice.class, RestResponseBodyAdvice.class,
         OpensabreServiceConfig.class, OpensabreSwaggerConfig.class})
 public class OpensabreWebMvcConfig {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public UserInterceptor opensabreUserInterceptor() {
+        return new UserInterceptor();
+    }
+
+    @Bean
+    public WebMvcConfigurer opensabreUserContextWebMvcConfigurer(UserInterceptor interceptor) {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addInterceptors(InterceptorRegistry registry) {
+                registry.addInterceptor(interceptor);
+            }
+        };
+    }
 }

--- a/opensabre-starter-webmvc/src/test/java/io/github/opensabre/webmvc/config/OpensabreWebMvcConfigTest.java
+++ b/opensabre-starter-webmvc/src/test/java/io/github/opensabre/webmvc/config/OpensabreWebMvcConfigTest.java
@@ -1,0 +1,23 @@
+package io.github.opensabre.webmvc.config;
+
+import io.github.opensabre.webmvc.interceptor.UserInterceptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class OpensabreWebMvcConfigTest {
+    @Test
+    void registersUserContextInterceptorForEveryServletApplication() {
+        OpensabreWebMvcConfig configuration = new OpensabreWebMvcConfig();
+        UserInterceptor interceptor = configuration.opensabreUserInterceptor();
+        WebMvcConfigurer configurer = configuration.opensabreUserContextWebMvcConfigurer(interceptor);
+        InterceptorRegistry registry = mock(InterceptorRegistry.class);
+
+        configurer.addInterceptors(registry);
+
+        verify(registry).addInterceptor(interceptor);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>0.7.6</revision>
+        <revision>0.7.7</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
## 变更
- 订阅 `opensabre-common.yml` 并校验、原子替换内部 Token 配置
- 拒绝非法或倒退版本，失败时保留上一份有效配置
- 增加 `/actuator/internalTokenKeyStatus` 实例确认端点（不暴露密钥）
- WebMVC 自动绑定已验证 JWT 用户到 `UserContextHolder`，修复审计记录为 system
- Framework 版本升级为 0.7.7

## 验证
- JDK 21 `mvn clean install`，15 个模块全部通过
- 覆盖有效刷新、非法密钥、乱序版本和 WebMVC 拦截器注册

Closes #59