### PR TITLE
chore: 发布 Framework 1.0.0

### DIFF
--- a/docs/migration-1.0.md
+++ b/docs/migration-1.0.md
@@ -18,7 +18,7 @@ OpenSabre 1.0 以 0.7.7 为功能基线直接升级到 Spring Boot 4，不提供
 
 ## 必须处理的破坏性变更
 
-1. 将 OpenSabre 父 POM 或 BOM 版本改为 `1.0.0-SNAPSHOT`，编译 release 改为 21。
+1. 将 OpenSabre 父 POM 或 BOM 版本改为 `1.0.0`，编译 release 改为 21。
 2. 删除 `bootstrap.yml`，把应用名、端口及云配置迁入 `application.yml`。
 3. 使用 `spring.config.import` 显式导入 Nacos 配置，例如：
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>1.0.0-SNAPSHOT</revision>
+        <revision>1.0.0</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
## 发布内容
- 将 Framework 版本从 1.0.0-SNAPSHOT 固化为 1.0.0
- 更新正式版迁移文档

## 验证
- Java 21 / Spring Boot 4.0.7
- 15 个模块 mvn clean verify 全部通过
- Boot 3 维护分支：support/boot3.x