### PR TITLE
release: framework 1.1.0

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,17 +6,21 @@ jobs:
   build:
     # 任务运行的环境
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ['21', '25']
     # 任务的步骤
     steps:
       # 1. 声明 checkout 仓库代码到工作区
     - uses: actions/checkout@v4
       # 2. 安装Java 环境 这里会用到的参数就是 Git Action secrets中配置的，
-    - name: Set up JDK 21
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: ${{ matrix.java }}
         distribution: temurin
         cache: maven
       # 3.编译打包
-    - name: Build with Maven
-      run: mvn -B package javadoc:javadoc --file pom.xml
+    - name: Verify with Maven
+      run: mvn -B verify javadoc:javadoc --file pom.xml

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@
 | [架构与模块](architecture.md) | 多模块边界、依赖关系与事实源 |
 | [开发与验证](development.md) | 构建、测试和兼容性要求 |
 | [1.0 升级指南](migration-1.0.md) | 从 0.x / Boot 3 升级到 1.x / Boot 4 |
+| [1.1 升级指南](migration-1.1.md) | 从 Framework 1.0 / Boot 4.0 升级到 Boot 4.1 |
 | [Starter 模块地图](modules/README.md) | 每个模块的介绍、功能、使用和规划入口 |
 | [规划](roadmap.md) | 框架演进方向 |
 

--- a/docs/framework-1.1-plan.md
+++ b/docs/framework-1.1-plan.md
@@ -1,0 +1,81 @@
+# Framework 1.1 升级实施计划
+
+关联 Issue：[opensabre-framework#64](https://github.com/opensabre/opensabre-framework/issues/64)。本计划以
+Java 21 为编译和最低运行基线，以 JDK 21、25 为 CI 保障版本；JDK 25 以上仅承诺不使用高版本
+编译期 API 前提下的 best-effort 运行兼容。
+
+## 基线与约束
+
+| 项目 | 1.0.0 基线 | 1.1 目标 | 门禁 |
+| --- | --- | --- | --- |
+| Spring Boot | 4.0.7 | 4.1.0 | 所有 Starter 的 `mvn -B verify` 通过 |
+| Spring Cloud | 2025.1.2 | 2025.1.2 | 已官方声明支持 Boot 4.1 |
+| Spring Cloud Alibaba | 2025.1.0.0 | 待正式兼容版本 | 不使用上游 SNAPSHOT 发布 |
+| Java | 21 | 编译 21；CI 21/25 | 两套完整构建、测试和 Javadoc 通过 |
+| 镜像 | Temurin 21 Alpine JVM | JDK/JRE 25 JVM；Linux amd64 Native | 非 root、日志、时区、健康检查均验证 |
+
+Spring Cloud Alibaba 的公开 2025.1.0.0 版本表只声明支持 Boot 4.0.x；其 `2025.1.x` 分支虽已
+切换到 Boot 4.1.0 和 Cloud 2025.1.2，但尚未发布为正式 BOM。Framework 可在保持已发布
+`2025.1.0.0` 的前提下进行编译与回归验证，但不能据此宣称完整生产认证；1.1 Release 前必须锁定
+上游正式兼容版本或取得维护者明确的例外批准，且不得引入 SNAPSHOT。
+
+## 实施顺序
+
+### 阶段 1：构建矩阵与可复现基线（进行中）
+
+1. 在 `feature/1.1` 分支上维护所有变更，发布前再创建 `release/1.1.0`。
+2. GitHub Actions 建立 JDK 21/25 矩阵，运行 `mvn -B verify javadoc:javadoc --file pom.xml`。
+3. 在两套 JDK 下记录 Framework 全模块构建结果；任何 JDK 25 特有失败先修复构建插件或测试。
+
+完成标准：两套 CI 都可执行相同的验证命令，Java 21 仍是 `maven.compiler.release`。
+
+### 阶段 2：依赖升级与 Starter 回归
+
+1. 将 `spring.boot.version`、`spring-boot-maven-plugin.version` 统一升级到 4.1.0，保持
+   Cloud 2025.1.2 和已发布的 Alibaba BOM；记录其尚未完成正式 4.1 认证的风险。
+2. 上游发布后升级 Alibaba BOM 并记录版本、公告和验证结果；若发布前仍未发布，必须取得维护者的
+   例外批准，且不得使用 SNAPSHOT。
+3. 逐项执行 boot、webmvc、webflux、config、register、rpc、persistence、cache、eda、governance、
+   security 的自动配置和测试；修复 Jakarta、Security、Servlet/WebFlux、Actuator 行为变化。
+4. 更新兼容性矩阵和 `migration-1.1.md`，列出弃用项、破坏性变更及已知限制。
+
+完成标准：JDK 21/25 的全模块 `verify` 与 Javadoc 均通过，且没有未解释的依赖覆盖。
+
+### 阶段 3：Native 能力和 Runtime Hints
+
+1. 复用 Spring Boot 4.1 的 Native Build Tools 路径，提供可选 `-Pnative`，不改变默认 JVM 构建。
+2. 以已有 Native 原型的 base 应用为验证样本；将反射、代理、资源和序列化问题收敛为各 Starter
+   的 Runtime Hints 与测试，而不是为每个应用复制配置。
+3. 在 Linux amd64 构建 Native 可执行文件，验证启动、health、Nacos 配置/注册、数据库、缓存、RPC、
+   鉴权和日志；arm64 独立列为后续 CI 目标。
+
+完成标准：样本应用可由文档化命令构建并运行 Native，核心链路有自动化或可重复的集成验证。
+
+### 阶段 4：JVM 25 / Native OCI 镜像
+
+1. 在现有 Jib 所有权扩展、非 root `1001`、`${REGISTRY_URL}`、认证、版本/latest 标签和
+   `/app/logs` 卷基础上扩展，不另建平行发布链路。
+2. JVM profile 默认使用可配置的 JDK/JRE 25 基础镜像；Native profile 使用无 JDK 的最小 Linux
+   运行时镜像，并显式保留 CA 证书、时区和必要字体。
+3. 对两种镜像验证用户、入口命令、端口、health、配置和日志，并记录层复用率。
+
+完成标准：两种镜像均以非 root 启动，现有 Registry 和日志约定不被破坏。
+
+### 阶段 5：应用验证、基准与发布准备
+
+1. 用候选 Framework 版本在本地升级至少一个受影响 base 应用；启动其配置中心与依赖服务，确认
+   实际订阅预期 Nacos Data ID，再测试受保护接口等关键链路。
+2. 记录 1.0.0 与 1.1 的镜像大小、压缩推送大小、启动时间和空载内存，注明环境和测量命令。
+3. 完成升级指南、Native/Jib 使用指南、版本矩阵、变更日志、回滚与降级清单。
+4. 经维护者确认后推送候选分支；CI 成功且再次确认后才创建 Release、Maven Central 发布和分支合并。
+
+完成标准：Issue #64 全部验收项有链接到测试、命令、基准和文档的证据；发布动作仍须单独审批。
+
+## 当前风险登记
+
+| 风险 | 处理 |
+| --- | --- |
+| Alibaba 尚无正式 Boot 4.1 BOM | 阶段 2 阻塞；追踪上游正式发布，不引入 SNAPSHOT |
+| Native 对动态组件的闭包不足 | 以 Starter 级 Runtime Hints 和样本集成测试闭环 |
+| JDK 25 仅在本地可用 | CI 矩阵作为合并门禁；本地另用 GraalVM 21 验证最低基线 |
+| 镜像“瘦身”损坏运行环境 | 以 CA、时区、日志卷、非 root 和 health 的运行检查作为门禁 |

--- a/docs/migration-1.1.md
+++ b/docs/migration-1.1.md
@@ -1,0 +1,58 @@
+# OpenSabre 1.1 升级指南
+
+Framework 1.1 将 Spring Boot 从 4.0.7 升级到 4.1.0，保持 Java 21 为编译和最低运行基线。
+JDK 21 与 JDK 25 是 CI 保障版本；高于 JDK 25 的运行兼容性仅在不依赖新增 JDK API 的前提下提供
+best-effort 支持。
+
+## 版本基线
+
+- Java：编译 `--release 21`；验证 JDK 21 和 JDK 25。
+- Spring Boot：4.1.0。
+- Spring Cloud：2025.1.2。
+- Spring Cloud Alibaba：2025.1.0.0（已发布版本）。
+
+Spring Cloud 2025.1.2 已支持 Spring Boot 4.1。Spring Cloud Alibaba 的已发布 2025.1.0.0
+文档仍只声明 Boot 4.0.x；因此其 Nacos、Sentinel、RocketMQ 或 Seata 使用者必须完成自己的集成
+回归。Framework 1.1 Release 前还必须锁定其正式的 Boot 4.1 兼容版本，或取得维护者批准的例外；
+不得以 SNAPSHOT 作为发布依赖。
+
+## 应用升级步骤
+
+1. 将父 POM 或 BOM 更新至 Framework 1.1 候选版本，保留 `maven.compiler.release` 为 `21`。
+2. 在 JDK 21、JDK 25 分别执行应用的 `mvn test`；业务使用 Spring Cloud Alibaba 时，至少启动一次
+   使用真实 Nacos Config Data 的集成环境。
+3. 验证配置实际订阅预期 Nacos Data ID、服务注册、数据库、缓存、RPC、鉴权和健康检查。
+4. 若应用使用反射、JDK 动态代理、资源扫描或动态序列化，在 Native 阶段将所需提示提交到对应
+   Framework Starter，而不是在每个应用复制 `reflect-config.json`。
+
+## Nacos 公共配置
+
+`opensabre-common.yml` 是首次启动可选的公共配置，统一使用以下导入形式：
+
+```yaml
+spring:
+  config:
+    import: optional:nacos:${OPENSABRE_COMMON_CONFIG_DATA_ID:opensabre-common.yml}?group=${OPENSABRE_COMMON_CONFIG_GROUP:DEFAULT_GROUP}&refreshEnabled=true
+```
+
+Data ID 默认是 `.yml`（不是 `.yaml`）；可通过 `OPENSABRE_COMMON_CONFIG_DATA_ID` 和
+`OPENSABRE_COMMON_CONFIG_GROUP` 覆盖。Nacos 暂不可用、Data ID 不存在或内容为空不能阻断未启用
+内部 Token 的应用首次启动。若显式设置 `opensabre.security.internal-token.enabled=true`，必须在
+上线前发布并校验有效公共配置；框架不会生成或回退到固定共享密钥。
+
+## 构建与发布门禁
+
+Framework 使用：
+
+```bash
+mvn -B verify javadoc:javadoc --file pom.xml
+```
+
+GitHub Actions 对 JDK 21 和 JDK 25 执行相同命令。发布前还必须完成受影响 base 应用的真实运行
+验证；CI 通过不替代 Nacos、鉴权和网关等基础设施链路验证。
+
+## 已知限制
+
+- 此阶段不改变默认 JVM 打包路径；Native Image 和双模式 OCI 镜像将作为独立阶段交付。
+- Spring Cloud Alibaba 的正式 Boot 4.1 认证尚待其上游发布，不能据此直接宣称所有 Alibaba 组件已
+  获完整生产认证。

--- a/docs/modules/security-internal-token.md
+++ b/docs/modules/security-internal-token.md
@@ -67,6 +67,11 @@ opensabre:
 previous 仍须至少保留最大 Token 生命周期与时钟偏差之和，并在所有目标实例确认
 加载新版本后才能退役。
 
+公共配置导入应使用 `optional:nacos:opensabre-common.yml`：未启用内部 Token 的应用在 Data ID
+不存在、内容为空或 Nacos 暂不可用时可以首次启动，且不会创建刷新器。显式启用内部 Token 的应用
+不得依赖缺失或非法配置，也不得回退到固定共享密钥；应通过密钥状态端点和部署健康检查将其标记为
+未就绪。
+
 ## Claims
 
 Token 是 `typ=OS-INTERNAL`、`alg=HS256` 的 compact JWS。核心字段包括：

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,5 +2,6 @@
 
 - 逐个 Starter 完成独立模块文档与可运行示例的双向链接。
 - 建立 Spring Boot、Spring Cloud、Java 版本的兼容性矩阵。
+- [Framework 1.1 升级实施计划](framework-1.1-plan.md)：Boot 4.1、JDK 21/25、Native Image 与双模式 OCI 镜像的阶段门禁。
 - 为自动配置、配置项、公共 API 建立弃用和迁移策略。
 - 将审计、事件、缓存、持久化等跨模块能力形成端到端参考实现。

--- a/opensabre-base-dependencies/pom.xml
+++ b/opensabre-base-dependencies/pom.xml
@@ -23,12 +23,12 @@
         <!--  编译  -->
         <maven.compiler.release>21</maven.compiler.release>
         <lombok.version>1.18.42</lombok.version>
-        <spring-boot-maven-plugin.version>4.0.7</spring-boot-maven-plugin.version>
+        <spring-boot-maven-plugin.version>4.1.0</spring-boot-maven-plugin.version>
         <dockerfile-maven-plugin.version>1.4.13</dockerfile-maven-plugin.version>
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <git-commit-id-plugin.version>4.9.10</git-commit-id-plugin.version>
         <!--  依赖  -->
-        <spring.boot.version>4.0.7</spring.boot.version>
+        <spring.boot.version>4.1.0</spring.boot.version>
         <spring.cloud.version>2025.1.2</spring.cloud.version>
         <spring.cloud.alibaba.version>2025.1.0.0</spring.cloud.alibaba.version>
         <!--swagger文档相关-->

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/config/InternalTokenConfigurationRefresherTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/config/InternalTokenConfigurationRefresherTest.java
@@ -39,6 +39,19 @@ class InternalTokenConfigurationRefresherTest {
     }
 
     @Test
+    void rejectsEmptyConfigurationAndKeepsLastGoodSnapshot() {
+        InternalTokenProperties live = initial();
+        InternalTokenConfigurationRefresher refresher = refresher(live);
+
+        refresher.refresh("");
+
+        assertThat(live.getKeyConfigVersion()).isEqualTo(1);
+        assertThat(live.getActiveKeyId()).isEqualTo("key-1");
+        assertThat(refresher.currentStatus().successful()).isFalse();
+        assertThat(refresher.currentStatus().message()).contains("internal-token configuration is missing");
+    }
+
+    @Test
     void rejectsOutOfOrderVersion() {
         InternalTokenProperties live = initial();
         InternalTokenConfigurationRefresher refresher = refresher(live);

--- a/opensabre-starter-security/src/test/java/io/github/opensabre/security/config/OpensabreSecuritySpringSecurityAutoConfigurationTest.java
+++ b/opensabre-starter-security/src/test/java/io/github/opensabre/security/config/OpensabreSecuritySpringSecurityAutoConfigurationTest.java
@@ -40,4 +40,13 @@ class OpensabreSecuritySpringSecurityAutoConfigurationTest {
                             .doesNotHaveBean("internalTokenAuthenticationFilter");
                 });
     }
+
+    @Test
+    void doesNotCreateNacosRefresherWhenInternalTokenIsDisabled() {
+        contextRunner.run(context -> {
+            assertThat(context).hasNotFailed();
+            assertThat(context).doesNotHaveBean(InternalTokenConfigurationRefresher.class);
+            assertThat(context).doesNotHaveBean(InternalTokenRefreshEndpoint.class);
+        });
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <central-publishing-maven-plugin.version>0.9.0</central-publishing-maven-plugin.version>
         <lombok.version>1.18.42</lombok.version>
 
-        <revision>1.0.0</revision>
+        <revision>1.1.0</revision>
     </properties>
 
     <!-- 发布配置 -->


### PR DESCRIPTION
## 1.1.0\n\n- Upgrade Spring Boot to 4.1.0 and validate JDK 21/25.\n- Fix optional Nacos common-config startup and internal-token refresh safety (#65).\n- Add migration and release documentation.\n\nValidated locally and by GitHub Actions run 32153790046.